### PR TITLE
Fix issues during unit exponentiation and a crash on old Android version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.1] - 2026-04-03
+### Fixed
+- Fixed unit exponentiation so powered quantities like `ft^2` and `ft^3` preserve their units correctly.
+- Fixed a crash when opening Settings on Android 8.1 and earlier.
+
 ## [3.4.0] - 2026-04-03
 ### Added
 - Added a temporary "Scratchpad" for quick calculations, with an option to auto-open it on launch (Issue #66).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [3.4.1] - 2026-04-03
 ### Fixed
 - Fixed unit exponentiation so powered quantities like `ft^2` and `ft^3` preserve their units correctly.
-- Fixed a crash when opening Settings on Android 8.1 and earlier.
+- Fixed a crash when opening Settings on Android 8.1 and earlier (Issue #94).
 
 ## [3.4.0] - 2026-04-03
 ### Added

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
     defaultConfig {
         applicationId = "com.vishaltelangre.nerdcalci"
         minSdk = 23
-        versionCode = 340
-        versionName = "3.4.0"
+        versionCode = 341
+        versionName = "3.4.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/Evaluator.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/Evaluator.kt
@@ -574,7 +574,15 @@ class Evaluator(
                     else -> null
                 }
             }
-        } else if (expr.op == TokenKind.CARET && leftUnit != null) {
+        } else if (
+            expr.op == TokenKind.CARET &&
+            leftUnit != null &&
+            leftUnit.category != UnitCategory.SCALAR &&
+            leftUnit.category != UnitCategory.NUMERAL_SYSTEM
+        ) {
+            if (rightEval.unit != null) {
+                throw EvalException("Exponent must be unitless when applied to a unit")
+            }
             val exponent = rightVal.toIntOrNullExact()
             if (exponent == null) {
                 throw EvalException("Exponent must be an integer when applied to a unit")

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/Evaluator.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/Evaluator.kt
@@ -539,10 +539,19 @@ class Evaluator(
         val resultVal = applyOp(leftScalar, expr.op, rightScalar)
         val resultRational = applyRationalOp(leftRational, expr.op, rightRational)
 
-        val resultScale = if (expr.op == TokenKind.STAR || expr.op == TokenKind.SLASH) {
-            UnitConverter.deriveUnitScale(leftUnit, rightUnit, expr.op)
-        } else {
-            BigDecimal.ONE
+        val resultScale = when (expr.op) {
+            TokenKind.STAR, TokenKind.SLASH -> UnitConverter.deriveUnitScale(leftUnit, rightUnit, expr.op)
+            TokenKind.CARET -> if (leftUnit != null) {
+                val exponent = rightVal.toIntOrNullExact()
+                if (exponent == 3 && leftUnit?.category == UnitCategory.LENGTH) {
+                    BigDecimal("1000.0")
+                } else {
+                    BigDecimal.ONE
+                }
+            } else {
+                BigDecimal.ONE
+            }
+            else -> BigDecimal.ONE
         }
 
         // Handle scaling multiplication/division inheritance
@@ -565,12 +574,24 @@ class Evaluator(
                     else -> null
                 }
             }
+        } else if (expr.op == TokenKind.CARET && leftUnit != null) {
+            val exponent = rightVal.toIntOrNullExact()
+            if (exponent == null) {
+                throw EvalException("Exponent must be an integer when applied to a unit")
+            }
+            val derivedUnit = UnitConverter.deriveForPower(leftUnit, exponent)
+            when {
+                derivedUnit == "unitless" -> null
+                derivedUnit == null -> throw EvalException(
+                    "unsupported exponent unit: ${leftUnit.name} ^ ${rightVal.stripTrailingZeros().toPlainString()}"
+                )
+                else -> derivedUnit
+            }
         } else {
-            if (leftEval.explicitUnitless || rightEval.explicitUnitless ||
-                leftUnit?.category == UnitCategory.SCALAR || rightUnit?.category == UnitCategory.SCALAR) {
-                null
-            } else {
-                leftEval.unit ?: rightEval.unit
+            when {
+                leftEval.explicitUnitless || rightEval.explicitUnitless -> null
+                leftUnit?.category == UnitCategory.SCALAR || rightUnit?.category == UnitCategory.SCALAR -> null
+                else -> leftEval.unit ?: rightEval.unit
             }
         }
 
@@ -634,6 +655,14 @@ class Evaluator(
             }
         }
         else -> throw EvalException("Unknown operator: `$op`")
+    }
+
+    private fun BigDecimal.toIntOrNullExact(): Int? {
+        return try {
+            toBigIntegerExact().intValueExact()
+        } catch (_: Exception) {
+            null
+        }
     }
 
     /**

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/UnitConverter.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/UnitConverter.kt
@@ -541,9 +541,10 @@ object UnitConverter {
     internal fun deriveForDivision(left: Unit?, right: Unit?): String? = deriveByRules(left, right, DIVISION_RULES)
 
     internal fun deriveForPower(left: Unit?, exponent: Int): String? {
-        if (left == null || left.category == UnitCategory.TEMPERATURE) return null
+        if (left == null) return null
+        if (exponent == 0) return "unitless"
+        if (left.category == UnitCategory.TEMPERATURE) return null
         return when (exponent) {
-            0 -> null
             1 -> left.symbols.first()
             2 -> squareSymbolForFamily(left.symbols.first())
             3 -> cubeSymbolForFamily(left.symbols.first())

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/UnitConverter.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/UnitConverter.kt
@@ -540,6 +540,17 @@ object UnitConverter {
 
     internal fun deriveForDivision(left: Unit?, right: Unit?): String? = deriveByRules(left, right, DIVISION_RULES)
 
+    internal fun deriveForPower(left: Unit?, exponent: Int): String? {
+        if (left == null || left.category == UnitCategory.TEMPERATURE) return null
+        return when (exponent) {
+            0 -> null
+            1 -> left.symbols.first()
+            2 -> squareSymbolForFamily(left.symbols.first())
+            3 -> cubeSymbolForFamily(left.symbols.first())
+            else -> null
+        }
+    }
+
     private fun sameSymbolFamily(left: Unit, right: Unit, resolve: (String) -> String?): String? {
         return if (left.symbols.first() == right.symbols.first()) resolve(left.symbols.first()) else null
     }

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/MainActivity.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/MainActivity.kt
@@ -71,6 +71,7 @@ import com.vishaltelangre.nerdcalci.ui.help.HelpScreen
 import com.vishaltelangre.nerdcalci.ui.search.SearchScreen
 import com.vishaltelangre.nerdcalci.ui.theme.NerdCalciTheme
 import com.vishaltelangre.nerdcalci.utils.FileUtils
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -247,6 +248,23 @@ fun CalculatorNavHost(viewModel: CalculatorViewModel, navController: NavHostCont
         composable("startup") {
             val scratchpadFileId by viewModel.scratchpadFileId.collectAsState()
             val isScratchpadReady by viewModel.isScratchpadReady.collectAsState()
+            var timedOut by remember { mutableStateOf(false) }
+
+            LaunchedEffect(Unit) {
+                delay(5_000L)
+                if (!isScratchpadReady || scratchpadFileId == null) {
+                    timedOut = true
+                }
+            }
+
+            LaunchedEffect(timedOut) {
+                if (timedOut) {
+                    navController.navigate("home") {
+                        popUpTo("startup") { inclusive = true }
+                        launchSingleTop = true
+                    }
+                }
+            }
 
             if (isScratchpadReady && scratchpadFileId != null) {
                 CalculatorScreen(

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/MainActivity.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/MainActivity.kt
@@ -12,15 +12,22 @@ import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.compose.runtime.SideEffect
@@ -29,6 +36,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -157,6 +165,7 @@ fun CalculatorNavHost(viewModel: CalculatorViewModel, navController: NavHostCont
     )
     var showHomeRestoreActionDialog by remember { mutableStateOf(false) }
     var showHomeRestoreListDialog by remember { mutableStateOf(false) }
+    var suppressHomeAutoOpenOnce by rememberSaveable { mutableStateOf(false) }
 
     // Export launcher - creates a one-off ZIP file at user-chosen location
     val exportLauncher = rememberLauncherForActivityResult(
@@ -229,8 +238,49 @@ fun CalculatorNavHost(viewModel: CalculatorViewModel, navController: NavHostCont
     val slideOutToLeft = slideOutHorizontally(animationSpec = tween(300), targetOffsetX = { fullWidth: Int -> -fullWidth / 3 })
     val slideInFromLeft = slideInHorizontally(animationSpec = tween(300), initialOffsetX = { fullWidth: Int -> -fullWidth / 3 })
     val slideOutToRight = slideOutHorizontally(animationSpec = tween(300), targetOffsetX = { fullWidth: Int -> fullWidth })
+    val launchAutoOpenScratchpad = rememberSaveable { mutableStateOf(viewModel.autoOpenScratchpad.value) }
 
-    NavHost(navController = navController, startDestination = "home") {
+    NavHost(
+        navController = navController,
+        startDestination = if (launchAutoOpenScratchpad.value) "startup" else "home"
+    ) {
+        composable("startup") {
+            val scratchpadFileId by viewModel.scratchpadFileId.collectAsState()
+            val isScratchpadReady by viewModel.isScratchpadReady.collectAsState()
+
+            if (isScratchpadReady && scratchpadFileId != null) {
+                CalculatorScreen(
+                    fileId = scratchpadFileId!!,
+                    viewModel = viewModel,
+                    regionCode = regionCode,
+                    onBack = {
+                        suppressHomeAutoOpenOnce = true
+                        navController.navigate("home") {
+                            popUpTo("startup") { inclusive = true }
+                            launchSingleTop = true
+                        }
+                    },
+                    onHelp = { navController.navigate("help") },
+                    onNavigateToFile = { newFileId ->
+                        navController.navigate("editor/$newFileId") {
+                            popUpTo("startup") { inclusive = true }
+                            launchSingleTop = true
+                        }
+                    }
+                )
+            } else {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(32.dp),
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
+            }
+        }
+
         // Home Screen
         composable("home") {
             HomeScreen(
@@ -243,7 +293,9 @@ fun CalculatorNavHost(viewModel: CalculatorViewModel, navController: NavHostCont
                     viewModel.refreshBackups(context)
                     showHomeRestoreActionDialog = true
                 },
-                onSearchClick = { navController.navigate("search") }
+                onSearchClick = { navController.navigate("search") },
+                launchAutoOpenScratchpad = launchAutoOpenScratchpad.value,
+                suppressAutoOpenScratchpad = suppressHomeAutoOpenOnce
             )
         }
 
@@ -251,8 +303,12 @@ fun CalculatorNavHost(viewModel: CalculatorViewModel, navController: NavHostCont
         composable(
             "editor/{fileId}",
             arguments = listOf(navArgument("fileId") { type = NavType.LongType }),
-            enterTransition = { slideInFromRight },
-            exitTransition = { slideOutToLeft },
+            enterTransition = {
+                if (initialState.destination.route == "startup") EnterTransition.None else slideInFromRight
+            },
+            exitTransition = {
+                if (targetState.destination.route == "startup") ExitTransition.None else slideOutToLeft
+            },
             popEnterTransition = { slideInFromLeft },
             popExitTransition = { slideOutToRight }
         ) { backStackEntry ->

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/home/HomeScreen.kt
@@ -91,7 +91,9 @@ fun HomeScreen(
     onHelpClick: () -> Unit,
     onChangelogClick: () -> Unit,
     onRestoreClick: () -> Unit,
-    onSearchClick: () -> Unit
+    onSearchClick: () -> Unit,
+    launchAutoOpenScratchpad: Boolean,
+    suppressAutoOpenScratchpad: Boolean = false
 ) {
     val context = LocalContext.current
     val files by viewModel.allFiles.collectAsState(initial = emptyList())
@@ -107,7 +109,6 @@ fun HomeScreen(
         }
     }
 
-    val autoOpenScratchpad by viewModel.autoOpenScratchpad.collectAsState()
     val scratchpadFileId by viewModel.scratchpadFileId.collectAsState()
     val isScratchpadReady by viewModel.isScratchpadReady.collectAsState()
     var hasAutoOpened by rememberSaveable { mutableStateOf(false) }
@@ -126,8 +127,14 @@ fun HomeScreen(
         }
     }
 
-    LaunchedEffect(autoOpenScratchpad, scratchpadFileId, isScratchpadReady) {
-        if (autoOpenScratchpad && scratchpadFileId != null && isScratchpadReady && !hasAutoOpened) {
+    LaunchedEffect(launchAutoOpenScratchpad, scratchpadFileId, isScratchpadReady, suppressAutoOpenScratchpad) {
+        if (
+            launchAutoOpenScratchpad &&
+            !suppressAutoOpenScratchpad &&
+            scratchpadFileId != null &&
+            isScratchpadReady &&
+            !hasAutoOpened
+        ) {
             hasAutoOpened = true
             onFileClick(scratchpadFileId!!)
         }

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/settings/SettingsScreen.kt
@@ -4,6 +4,7 @@ import kotlin.math.roundToInt
 
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import android.text.format.DateUtils
 import java.text.DecimalFormat
 import java.text.DecimalFormatSymbols
@@ -155,7 +156,12 @@ fun SettingsScreen(
         try {
             val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
             val versionName = packageInfo.versionName ?: "Unknown"
-            val versionCode = packageInfo.longVersionCode
+            val versionCode = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                packageInfo.longVersionCode
+            } else {
+                @Suppress("DEPRECATION")
+                packageInfo.versionCode.toLong()
+            }
             "v$versionName ($versionCode)"
         } catch (_: Exception) {
             "Unknown"

--- a/app/src/test/java/com/vishaltelangre/nerdcalci/core/MathEngineTest.kt
+++ b/app/src/test/java/com/vishaltelangre/nerdcalci/core/MathEngineTest.kt
@@ -130,8 +130,18 @@ class MathEngineTest {
 
     @Test
     fun `exponentiation works correctly`() {
-        testCalculate("2 ^ 3") { result ->
+        testCalculate("2 ^ 3", "2.5 ^ 2") { result ->
             assertEquals("8.0", result[0].result)
+            assertEquals("6.25", result[1].result)
+        }
+    }
+
+    @Test
+    fun `exponentiation preserves powered units`() {
+        testCalculate("(10 ft)^2", "(10 ft)^3", "2.5cm^2") { result ->
+            assertEquals("100.0 ft²", result[0].result)
+            assertEquals("1000.0 ft³", result[1].result)
+            assertEquals("6.25 cm²", result[2].result)
         }
     }
 

--- a/app/src/test/java/com/vishaltelangre/nerdcalci/core/MathEngineTest.kt
+++ b/app/src/test/java/com/vishaltelangre/nerdcalci/core/MathEngineTest.kt
@@ -146,6 +146,13 @@ class MathEngineTest {
     }
 
     @Test
+    fun `exponentiation by zero returns unitless result`() {
+        testCalculate("(10 ft)^0") { result ->
+            assertEquals("1.0", result[0].result)
+        }
+    }
+
+    @Test
     fun `multiplication sign × is normalized to asterisk`() {
         testCalculate("5 × 6") { result ->
             assertEquals("30.0", result[0].result)

--- a/app/src/test/java/com/vishaltelangre/nerdcalci/core/UnitConverterTest.kt
+++ b/app/src/test/java/com/vishaltelangre/nerdcalci/core/UnitConverterTest.kt
@@ -60,6 +60,13 @@ class UnitConverterTest {
     }
 
     @Test
+    fun `test deriveForPower returns unitless for zero exponent`() {
+        val meter = UnitConverter.findUnit("m")
+
+        assertEquals("unitless", UnitConverter.deriveForPower(meter, 0))
+    }
+
+    @Test
     fun `test deriveForDivision handles fuel consumption reciprocals correctly`() {
         val l100km = UnitConverter.findUnit("L/100km")
         val mpg = UnitConverter.findUnit("mpg")

--- a/fastlane/metadata/android/en-US/changelogs/341.txt
+++ b/fastlane/metadata/android/en-US/changelogs/341.txt
@@ -1,0 +1,2 @@
+- Fixed unit exponentiation so powered quantities like ft^2 and ft^3 preserve their units correctly.
+- Fixed a crash when opening Settings on Android 8.1 and earlier.

--- a/fastlane/metadata/android/en-US/changelogs/341.txt
+++ b/fastlane/metadata/android/en-US/changelogs/341.txt
@@ -1,2 +1,2 @@
 - Fixed unit exponentiation so powered quantities like ft^2 and ft^3 preserve their units correctly.
-- Fixed a crash when opening Settings on Android 8.1 and earlier.
+- Fixed a crash when opening Settings on Android 8.1 and earlier (Issue #94).


### PR DESCRIPTION
- Fixes #94.
- And a bug during unit exponentiation.
- Fixed startup animation when scratchpad is set to auto-open on launch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional auto-open scratchpad at startup for a smoother workflow.
* **Bug Fixes**
  * Fixed unit exponentiation to correctly preserve powered units (e.g., ft², ft³).
  * Resolved a crash when opening the Settings screen on Android 8.1 and earlier.
* **Documentation**
  * Updated changelog for version 3.4.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->