### PR TITLE
Add expansion energy units, dozen multiplier, and motion derivation rules

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -722,18 +722,22 @@ cos(60 degree) # 0.5
 
 ### Energy
 
-| Unit                 | Symbols (Aliases)                             | Example     |
-| :------------------- | :-------------------------------------------- | :---------- |
-| Joule                | `J`, `joule`, `joules`                        | `10 J`      |
-| Kilojoule            | `kJ`, `kilojoule`, `kilojoules`               | `10 kJ`     |
-| Megajoule            | `MJ`, `megajoule`, `megajoules`               | `10 MJ`     |
-| Calorie              | `cal`, `calorie`, `calories`                  | `10 cal`    |
-| Kilocalorie          | `kCal`, `kcal`, `kilocalorie`, `kilocalories` | `10 kCal`   |
-| Watt hour            | `Wh`, `watt hour`, `watt hours`               | `10 Wh`     |
-| Kilowatt hour        | `kWh`, `kilowatt hour`, `kilowatt hours`      | `10 kWh`    |
-| Electron volt        | `eV`, `electronvolt`, `electron volts`        | `10 eV`     |
-| Foot pound-force     | `ft_lbf`, `foot_pound`                         | `10 ft_lbf` |
-| British thermal unit | `BTU`, `btu`                                  | `10 BTU`    |
+| Unit                       | Symbols (Aliases)                                                                     | Example     |
+|:---------------------------|:--------------------------------------------------------------------------------------|:------------|
+| Joule                      | `J`, `joule`, `joules`                                                                | `10 J`      |
+| Kilojoule                  | `kJ`, `kilojoule`, `kilojoules`                                                       | `10 kJ`     |
+| Megajoule                  | `MJ`, `megajoule`, `megajoules`                                                       | `10 MJ`     |
+| Gigajoule                  | `GJ`, `gigajoule`, `gigajoules`                                                       | `10 GJ`     |
+| Calorie                    | `cal`, `calorie`, `calories`                                                          | `10 cal`    |
+| Kilocalorie                | `kCal`, `kcal`, `kilocalorie`, `kilocalories`                                         | `10 kCal`   |
+| Watt hour                  | `Wh`, `watt hour`, `watt hours`                                                       | `10 Wh`     |
+| Kilowatt hour              | `kWh`, `kilowatt hour`, `kilowatt hours`                                              | `10 kWh`    |
+| Electron volt              | `eV`, `electronvolt`, `electron volts`                                                | `10 eV`     |
+| Foot pound-force           | `ft_lbf`, `foot_pound`                                                                | `10 ft_lbf` |
+| British thermal unit       | `BTU`, `btu`                                                                          | `10 BTU`    |
+| Tons of TNT equivalent     | `tTNT`, `ton of TNT`, `tons of TNT`, `tonne of TNT`, `tonnes of TNT`                  | `10 tTNT`   |
+| Kilotons of TNT equivalent | `ktTNT`, `kiloton of TNT`, `kilotons of TNT`, `kilotonne of TNT`, `kilotonnes of TNT` | `10 ktTNT`  |
+| Megatons of TNT equivalent | `MtTNT`, `megaton of TNT`, `megatons of TNT`, `megatonne of TNT`, `megatonnes of TNT` | `10 MtTNT`  |
 
 ### Power
 
@@ -844,15 +848,16 @@ em = 20
 
 NerdCalci expands numeric representations supporting standard numeral naming conventions efficiently with scalable word suffixes:
 
-| Word       | Multiplier          | Example      | Evaluates to |
-| :--------- | :------------------ | :----------- | :----------- |
-| `hundred`  | `100`               | `5 hundred`  | `500`        |
-| `thousand` | `1,000`             | `2 thousand` | `2000`       |
-| `lakh`     | `100,000`           | `10 lakh`    | `1000000`    |
-| `million`  | `1,000,000`         | `5 million`  | `5000000`    |
-| `crore`    | `10,000,000`        | `1.5 crore`  | `15000000`   |
-| `billion`  | `1,000,000,000`     | `1 billion`  | `1000000000` |
-| `trillion` | `1,000,000,000,000` | `1 trillion` | `1E12`       |
+| Word       | Multiplier           | Example       | Evaluates to |
+|:-----------|:---------------------|:--------------|:-------------|
+| `dozen`    | `12`                 | `4 dozen`     | `48`         |
+| `hundred`  | `100`                | `5 hundred`   | `500`        |
+| `thousand` | `1,000`              | `2 thousand`  | `2000`       |
+| `lakh`     | `100,000`            | `10 lakh`     | `1000000`    |
+| `million`  | `1,000,000`          | `5 million`   | `5000000`    |
+| `crore`    | `10,000,000`         | `1.5 crore`   | `15000000`   |
+| `billion`  | `1,000,000,000`      | `1 billion`   | `1000000000` |
+| `trillion` | `1,000,000,000,000`  | `1 trillion`  | `1E12`       |
 
 ### Radix base conversions
 

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/Parser.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/Parser.kt
@@ -585,6 +585,7 @@ class Parser(private val tokens: List<Token>) {
 
     private fun getNumeralMultiplier(word: String): BigDecimal? {
         return when (word.lowercase()) {
+            "dozen", "dozens" -> BigDecimal("12")
             "hundred", "hundreds" -> BigDecimal("100")
             "thousand", "thousands" -> BigDecimal("1000")
             "lakh", "lakhs" -> BigDecimal("100000")

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/UnitConverter.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/UnitConverter.kt
@@ -54,6 +54,9 @@ object UnitConverter {
         }),
         UnitRule(UnitCategory.SPEED, UnitCategory.TIME, result = { left, right ->
             speedAndTimeToLength(left.symbols[0], right.symbols[0])
+        }),
+        UnitRule(UnitCategory.TIME, UnitCategory.SPEED, result = { left, right ->
+            speedAndTimeToLength(right.symbols[0], left.symbols[0])
         })
     )
 

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/UnitConverter.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/UnitConverter.kt
@@ -633,19 +633,19 @@ object UnitConverter {
     }
 
     private fun speedAndTimeToLength(speed: String, time: String): String? {
-        if(speed == "mps" && time == "s") return "m"
-        if(speed == "kmh" && time == "h") return "km"
-        if(speed == "mph" && time == "h") return "mi"
-        if(speed == "fps" && time == "s") return "ft"
-        return null;
+        if (speed == "mps" && time == "s") return "m"
+        if (speed == "kmh" && time == "h") return "km"
+        if (speed == "mph" && time == "h") return "mi"
+        if (speed == "fps" && time == "s") return "ft"
+        return null
     }
 
     private fun lengthAndTimeToSpeed(length: String, time: String): String? {
-        if(length == "m" && time == "s") return "mps"
-        if(length == "km" && time == "h") return "kmh"
-        if(length == "mi" && time == "h") return "mph"
-        if(length == "ft" && time == "s") return "fps"
-        return null;
+        if (length == "m" && time == "s") return "mps"
+        if (length == "km" && time == "h") return "kmh"
+        if (length == "mi" && time == "h") return "mph"
+        if (length == "ft" && time == "s") return "fps"
+        return null
     }
 
     fun isNumeralSystemSymbol(symbol: String): Boolean {

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/UnitConverter.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/UnitConverter.kt
@@ -211,7 +211,7 @@ object UnitConverter {
         Unit("Meter per second", listOf("mps", "meters per second"), UnitCategory.SPEED, BigDecimal.ONE),
         Unit("Kilometer per hour", listOf("kmh", "kph", "kmph", "kilometers per hour"), UnitCategory.SPEED, BigDecimal.ONE.divide(BigDecimal("3.6"), JavaMathContext.DECIMAL128)),
         Unit("Miles per hour", listOf("mph", "miph", "miles per hour"), UnitCategory.SPEED, BigDecimal("0.44704")),
-        Unit("Knot", listOf("kn", "knot", "knots"), UnitCategory.SPEED, BigDecimal("0.514444")),
+        Unit("Knot", listOf("kn", "knot", "knots"), UnitCategory.SPEED, BigDecimal("5093").divide(BigDecimal("9900"), JavaMathContext.DECIMAL128)),
         Unit("Feet per second", listOf("fps", "feet per second"), UnitCategory.SPEED, BigDecimal("0.3048")),
         Unit("Speed of light", listOf("speed of light"), UnitCategory.SPEED, BigDecimal("299792458.0")),
 

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/UnitConverter.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/UnitConverter.kt
@@ -645,8 +645,7 @@ object UnitConverter {
         else -> null
     }
 
-    private fun matchLengthToSpeed(length: String): String? = when(length)
-    {
+    private fun matchLengthToSpeed(length: String): String? = when(length) {
         "pm" -> "mps"
         "nm" -> "mps"
         "µm" -> "mps"
@@ -661,6 +660,7 @@ object UnitConverter {
         "NM" -> "kn"
         "inch" -> "fps"
         "ft" -> "fps"
+        "yd" -> "fps"
         "ly" -> "mps"
         "Å" -> "mps"
         "au" -> "mps"

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/UnitConverter.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/UnitConverter.kt
@@ -51,6 +51,9 @@ object UnitConverter {
         }),
         UnitRule(UnitCategory.LENGTH, UnitCategory.AREA, result = { left, right ->
             sameAreaLengthFamily(right, left)?.let { cubeSymbolForFamily(it) }
+        }),
+        UnitRule(UnitCategory.SPEED, UnitCategory.TIME, result = { left, right ->
+            speedAndTimeToLength(left.symbols[0], right.symbols[0])
         })
     )
 
@@ -79,7 +82,10 @@ object UnitConverter {
         UnitRule(UnitCategory.DATA_RATE, UnitCategory.DATA_RATE, result = { _, _ -> "unitless" }),
         UnitRule(UnitCategory.FORCE, UnitCategory.FORCE, result = { _, _ -> "unitless" }),
         UnitRule(UnitCategory.PRESSURE, UnitCategory.PRESSURE, result = { _, _ -> "unitless" }),
-        UnitRule(UnitCategory.NUMERAL_SYSTEM, UnitCategory.NUMERAL_SYSTEM, result = { _, _ -> "unitless" })
+        UnitRule(UnitCategory.NUMERAL_SYSTEM, UnitCategory.NUMERAL_SYSTEM, result = { _, _ -> "unitless" }),
+        UnitRule(UnitCategory.LENGTH, UnitCategory.TIME, result = { left, right ->
+            lengthAndTimeToSpeed(left.symbols[0], right.symbols[0])
+        })
     )
 
     // Base units:
@@ -624,6 +630,22 @@ object UnitConverter {
         "inch" -> findUnit("in³")?.symbols?.first()
         "ft" -> findUnit("ft³")?.symbols?.first()
         else -> null
+    }
+
+    private fun speedAndTimeToLength(speed: String, time: String): String? {
+        if(speed == "mps" && time == "s") return "m"
+        if(speed == "kmh" && time == "h") return "km"
+        if(speed == "mph" && time == "h") return "mi"
+        if(speed == "fps" && time == "s") return "ft"
+        return null;
+    }
+
+    private fun lengthAndTimeToSpeed(length: String, time: String): String? {
+        if(length == "m" && time == "s") return "mps"
+        if(length == "km" && time == "h") return "kmh"
+        if(length == "mi" && time == "h") return "mph"
+        if(length == "ft" && time == "s") return "fps"
+        return null;
     }
 
     fun isNumeralSystemSymbol(symbol: String): Boolean {

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/UnitConverter.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/UnitConverter.kt
@@ -344,6 +344,7 @@ object UnitConverter {
         Unit("Binary", listOf("bin", "binary"), UnitCategory.NUMERAL_SYSTEM, BigDecimal("2.0")),
 
         // --- SCALAR MULTIPLIERS ---
+        Unit("Dozens", listOf("dozen", "dozens"), UnitCategory.SCALAR, BigDecimal("12.0")),
         Unit("Hundred", listOf("hundred", "hundreds"), UnitCategory.SCALAR, BigDecimal("100.0")),
         Unit("Thousand", listOf("thousand", "thousands"), UnitCategory.SCALAR, BigDecimal("1000.0")),
         Unit("Lakh", listOf("lakh", "lakhs"), UnitCategory.SCALAR, BigDecimal("100000.0")),

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/UnitConverter.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/UnitConverter.kt
@@ -88,6 +88,9 @@ object UnitConverter {
         UnitRule(UnitCategory.NUMERAL_SYSTEM, UnitCategory.NUMERAL_SYSTEM, result = { _, _ -> "unitless" }),
         UnitRule(UnitCategory.LENGTH, UnitCategory.TIME, result = { left, right ->
             matchLengthToSpeed(left.symbols[0])
+        }),
+        UnitRule(UnitCategory.LENGTH, UnitCategory.SPEED, result = { left, right ->
+            matchSpeedToTime(right.symbols[0])
         })
     )
 
@@ -664,6 +667,21 @@ object UnitConverter {
         "ly" -> "mps"
         "Å" -> "mps"
         "au" -> "mps"
+        "px" -> "mps"
+        "pixel" -> "mps"
+        "pixels" -> "mps"
+        "pt" -> "mps"
+        "em" -> "mps"
+        else -> null
+    }
+
+    private fun matchSpeedToTime(speed: String): String? = when(speed) {
+        "mps" -> "s"
+        "kmh" -> "h"
+        "mph" -> "h"
+        "kn" -> "h"
+        "fps" -> "s"
+        "speed of light" -> "s"
         else -> null
     }
 

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/UnitConverter.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/UnitConverter.kt
@@ -53,10 +53,10 @@ object UnitConverter {
             sameAreaLengthFamily(right, left)?.let { cubeSymbolForFamily(it) }
         }),
         UnitRule(UnitCategory.SPEED, UnitCategory.TIME, result = { left, right ->
-            speedAndTimeToLength(left.symbols[0], right.symbols[0])
+            matchSpeedToLength(left.symbols[0])
         }),
         UnitRule(UnitCategory.TIME, UnitCategory.SPEED, result = { left, right ->
-            speedAndTimeToLength(right.symbols[0], left.symbols[0])
+            matchSpeedToLength(right.symbols[0])
         })
     )
 
@@ -87,7 +87,7 @@ object UnitConverter {
         UnitRule(UnitCategory.PRESSURE, UnitCategory.PRESSURE, result = { _, _ -> "unitless" }),
         UnitRule(UnitCategory.NUMERAL_SYSTEM, UnitCategory.NUMERAL_SYSTEM, result = { _, _ -> "unitless" }),
         UnitRule(UnitCategory.LENGTH, UnitCategory.TIME, result = { left, right ->
-            lengthAndTimeToSpeed(left.symbols[0], right.symbols[0])
+            matchLengthToSpeed(left.symbols[0])
         })
     )
 
@@ -635,23 +635,24 @@ object UnitConverter {
         else -> null
     }
 
-    private fun speedAndTimeToLength(speed: String, time: String): String? {
-        if (speed == "mps" && time == "s") return "m"
-        if (speed == "kmh" && time == "h") return "km"
-        if (speed == "mph" && time == "h") return "mi"
-        if (speed == "kn" && time == "h") return "NM"
-        if (speed == "fps" && time == "s") return "ft"
-        if (speed == "speed of light" && time == "s") return "m"
-        return null
+    private fun matchSpeedToLength(speed: String): String? = when (speed) {
+        "mps" -> "m"
+        "kmh" -> "km"
+        "mph" -> "mi"
+        "kn" -> "NM"
+        "fps" -> "ft"
+        "speed of light" -> "m"
+        else -> null
     }
 
-    private fun lengthAndTimeToSpeed(length: String, time: String): String? {
-        if (length == "m" && time == "s") return "mps"
-        if (length == "km" && time == "h") return "kmh"
-        if (length == "mi" && time == "h") return "mph"
-        if (length == "NM" && time == "h") return "kn"
-        if (length == "ft" && time == "s") return "fps"
-        return null
+    private fun matchLengthToSpeed(length: String): String? = when(length)
+    {
+        "m" -> "mps"
+        "km" -> "kmh"
+        "mi" -> "mph"
+        "NM" -> "kn"
+        "ft" -> "fps"
+        else -> null
     }
 
     fun isNumeralSystemSymbol(symbol: String): Boolean {

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/UnitConverter.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/UnitConverter.kt
@@ -249,6 +249,7 @@ object UnitConverter {
         Unit("Joule", listOf("J", "joule", "joules"), UnitCategory.ENERGY, BigDecimal.ONE),
         Unit("Kilojoule", listOf("kJ", "kilojoule", "kilojoules"), UnitCategory.ENERGY, BigDecimal("1000.0")),
         Unit("Megajoule", listOf("MJ", "megajoule", "megajoules"), UnitCategory.ENERGY, BigDecimal("1e6")),
+        Unit("Gigajoule", listOf("GJ", "gigajoule", "gigajoules"), UnitCategory.ENERGY, BigDecimal("1e9")),
         Unit("Calorie", listOf("cal", "calorie", "calories"), UnitCategory.ENERGY, BigDecimal("4.184")),
         Unit("Kilocalorie", listOf("kCal", "kcal", "kilocalorie", "kilocalories"), UnitCategory.ENERGY, BigDecimal("4184.0")),
         Unit("Watt hour", listOf("Wh", "watt hour", "watt hours"), UnitCategory.ENERGY, BigDecimal("3600.0")),
@@ -256,6 +257,9 @@ object UnitConverter {
         Unit("Electron volt", listOf("eV", "electronvolt", "electron volts"), UnitCategory.ENERGY, BigDecimal("1.602176634e-19")),
         Unit("Foot pound-force", listOf("ft lbf", "ft_lbf", "foot_pound"), UnitCategory.ENERGY, BigDecimal("1.3558179483314")),
         Unit("British thermal unit", listOf("BTU", "btu"), UnitCategory.ENERGY, BigDecimal("1055.05585262")),
+        Unit("Tons of TNT equivalent", listOf("tTNT", "ton of TNT", "tons of TNT", "tonne of TNT", "tonnes of TNT"), UnitCategory.ENERGY, BigDecimal("4.184e9")),
+        Unit("Kilotons of TNT equivalent", listOf("ktTNT", "kiloton of TNT", "kilotons of TNT", "kilotonne of TNT", "kilotonnes of TNT"), UnitCategory.ENERGY, BigDecimal("4.184e12")),
+        Unit("Megatons of TNT equivalent", listOf("MtTNT", "megaton of TNT", "megatons of TNT", "megatonne of TNT", "megatonnes of TNT"), UnitCategory.ENERGY, BigDecimal("4.184e15")),
 
         // --- POWER --- (Base: Watt)
         Unit("Watt", listOf("W", "watt", "watts"), UnitCategory.POWER, BigDecimal.ONE),

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/UnitConverter.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/UnitConverter.kt
@@ -636,7 +636,9 @@ object UnitConverter {
         if (speed == "mps" && time == "s") return "m"
         if (speed == "kmh" && time == "h") return "km"
         if (speed == "mph" && time == "h") return "mi"
+        if (speed == "kn" && time == "h") return "NM"
         if (speed == "fps" && time == "s") return "ft"
+        if (speed == "speed of light" && time == "s") return "m"
         return null
     }
 
@@ -644,6 +646,7 @@ object UnitConverter {
         if (length == "m" && time == "s") return "mps"
         if (length == "km" && time == "h") return "kmh"
         if (length == "mi" && time == "h") return "mph"
+        if (length == "NM" && time == "h") return "kn"
         if (length == "ft" && time == "s") return "fps"
         return null
     }

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/UnitConverter.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/UnitConverter.kt
@@ -647,11 +647,23 @@ object UnitConverter {
 
     private fun matchLengthToSpeed(length: String): String? = when(length)
     {
+        "pm" -> "mps"
+        "nm" -> "mps"
+        "µm" -> "mps"
+        "mm" -> "mps"
+        "cm" -> "mps"
+        "dm" -> "mps"
         "m" -> "mps"
         "km" -> "kmh"
+        "fur" -> "mph"
         "mi" -> "mph"
+        "ftm" -> "kn"
         "NM" -> "kn"
+        "inch" -> "fps"
         "ft" -> "fps"
+        "ly" -> "mps"
+        "Å" -> "mps"
+        "au" -> "mps"
         else -> null
     }
 

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorViewModel.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorViewModel.kt
@@ -198,7 +198,7 @@ class CalculatorViewModel(
 
     fun onValidateLaunchFile(fileId: Long, callback: (Boolean) -> Unit) {
         viewModelScope.launch {
-            val exists = withContext(Dispatchers.IO) {
+            val exists = withContext(ioDispatcher) {
                 dao.getFileById(fileId) != null
             }
             callback(exists)
@@ -206,7 +206,7 @@ class CalculatorViewModel(
     }
 
     private suspend fun resolveAutoOpenFile() {
-        withContext(Dispatchers.IO) {
+        withContext(ioDispatcher) {
             try {
                 val mode = _launchMode.value
                 val fileId = when (mode) {
@@ -274,7 +274,7 @@ class CalculatorViewModel(
     }
 
     private suspend fun ensureScratchpadExists() {
-        withContext(Dispatchers.IO) {
+        withContext(ioDispatcher) {
             try {
                 val existing = dao.getTemporaryFile()
                 if (existing != null) {
@@ -473,7 +473,7 @@ class CalculatorViewModel(
     fun validateLaunchFile(fileId: Long? = null, onResult: ((Boolean) -> Unit)? = null) {
         val id = fileId ?: if (_launchMode.value == LaunchMode.SPECIFIC_FILE) _launchFileId.value else null
         if (id != null) {
-            viewModelScope.launch(Dispatchers.IO) {
+            viewModelScope.launch(ioDispatcher) {
                 val exists = dao.getFileById(id) != null
                 if (!exists && fileId == null) { // Only auto-reset if we're validating the CURRENT setting
                     withContext(Dispatchers.Main) {
@@ -627,7 +627,7 @@ class CalculatorViewModel(
     }
 
     fun refreshBackups(context: Context) {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(ioDispatcher) {
             _availableBackups.value = BackupManager.listBackups(context)
             _lastBackupAt.value = (prefs ?: BackupManager.prefs(context))
                 .getLong(BackupManager.PREF_LAST_BACKUP_AT, 0L)
@@ -719,7 +719,7 @@ class CalculatorViewModel(
 
     fun getLines(fileId: Long): Flow<List<LineEntity>> = dao.getLinesForFile(fileId)
 
-    suspend fun getLineCount(fileId: Long): Int = withContext(Dispatchers.IO) {
+    suspend fun getLineCount(fileId: Long): Int = withContext(ioDispatcher) {
         dao.getLineCountForFile(fileId)
     }
 
@@ -755,7 +755,7 @@ class CalculatorViewModel(
     }
 
     fun undo(fileId: Long, rationalMode: Boolean? = null) {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(ioDispatcher) {
             calculationMutex.withLock {
                 if (isFileLocked(fileId)) return@withLock
                 val undoStack = undoStacks[fileId] ?: return@withLock
@@ -777,7 +777,7 @@ class CalculatorViewModel(
     }
 
     fun redo(fileId: Long, rationalMode: Boolean? = null) {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(ioDispatcher) {
             calculationMutex.withLock {
                 if (isFileLocked(fileId)) return@withLock
                 val redoStack = redoStacks[fileId] ?: return@withLock
@@ -810,7 +810,7 @@ class CalculatorViewModel(
     }
 
     fun clearHistory(fileId: Long) {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(ioDispatcher) {
             calculationMutex.withLock {
                 if (isFileLocked(fileId)) return@withLock
                 undoStacks[fileId]?.clear()
@@ -821,7 +821,7 @@ class CalculatorViewModel(
     }
 
     fun recalculateFile(fileId: Long, rationalMode: Boolean? = null) {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(ioDispatcher) {
             calculationMutex.withLock {
                 val allLines = dao.getLinesForFileSync(fileId)
                 val effectiveRationalMode = rationalMode ?: _rationalMode.value
@@ -865,7 +865,7 @@ class CalculatorViewModel(
     }
 
     suspend fun getLineErrorMessage(fileId: Long, targetLineId: Long, rationalMode: Boolean? = null): String? {
-        return withContext(Dispatchers.IO) {
+        return withContext(ioDispatcher) {
             val file = dao.getFileById(fileId) ?: return@withContext null
             val allLines = dao.getLinesForFileSync(fileId)
             val targetIndex = allLines.indexOfFirst { it.id == targetLineId }
@@ -875,7 +875,7 @@ class CalculatorViewModel(
     }
 
     fun createNewFile(context: Context, onCreated: (Long) -> Unit = {}) {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(ioDispatcher) {
             val fileId = dao.createNewFile("Untitled", System.currentTimeMillis())
             if (SyncManager.isSyncActive(context)) {
                 syncFiles(context)
@@ -885,7 +885,7 @@ class CalculatorViewModel(
     }
 
     fun duplicateFile(sourceFileId: Long, onCreated: (Long) -> Unit = {}) {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(ioDispatcher) {
             val fileId = dao.duplicateFile(sourceFileId, System.currentTimeMillis())
             if (fileId != null) {
                 withContext(Dispatchers.Main) { onCreated(fileId) }
@@ -900,7 +900,7 @@ class CalculatorViewModel(
         afterLineId: Long? = null,
         rationalMode: Boolean? = null
     ): Long {
-        return withContext(Dispatchers.IO) {
+        return withContext(ioDispatcher) {
             calculationMutex.withLock {
                 if (isFileLocked(fileId)) return@withLock -1L
                 // Save state for undo
@@ -939,7 +939,7 @@ class CalculatorViewModel(
         currentExpression: String? = null,
         rationalMode: Boolean? = null
     ): Long {
-        return withContext(Dispatchers.IO) {
+        return withContext(ioDispatcher) {
             calculationMutex.withLock {
                 val line = dao.getLineById(lineId) ?: return@withLock -1L
                 val fileId = line.fileId
@@ -985,7 +985,7 @@ class CalculatorViewModel(
         currentLineId: Long,
         rationalMode: Boolean? = null
     ) {
-        withContext(Dispatchers.IO) {
+        withContext(ioDispatcher) {
             calculationMutex.withLock {
                 val prevLine = dao.getLineById(prevLineId) ?: return@withLock
                 val currentLine = dao.getLineById(currentLineId) ?: return@withLock
@@ -1081,7 +1081,7 @@ class CalculatorViewModel(
     }
 
     suspend fun deleteFile(context: Context, fileId: Long): Boolean {
-        return withContext(Dispatchers.IO) {
+        return withContext(ioDispatcher) {
             calculationMutex.withLock {
                 performSyncAwareDelete(context, fileId)
             }
@@ -1089,7 +1089,7 @@ class CalculatorViewModel(
     }
 
     fun hideFile(fileId: Long) {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(ioDispatcher) {
             calculationMutex.withLock {
                 if (!_excludedFileIds.value.contains(fileId)) {
                     _excludedFileIds.value = _excludedFileIds.value + fileId
@@ -1099,7 +1099,7 @@ class CalculatorViewModel(
     }
 
     fun undoHideFile(fileId: Long) {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(ioDispatcher) {
             calculationMutex.withLock {
                 _excludedFileIds.value = _excludedFileIds.value - fileId
             }
@@ -1107,7 +1107,7 @@ class CalculatorViewModel(
     }
 
     fun permanentDeleteExclusions(context: Context) {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(ioDispatcher) {
             calculationMutex.withLock {
                 val idsToDelete = _excludedFileIds.value
                 if (idsToDelete.isEmpty()) return@withLock
@@ -1124,7 +1124,7 @@ class CalculatorViewModel(
      * the home screen with accidentally created empty files.
      */
     suspend fun deleteFileIfEmptyAndRecent(fileId: Long) {
-        withContext(Dispatchers.IO) {
+        withContext(ioDispatcher) {
             calculationMutex.withLock {
                 val file = dao.getFileById(fileId) ?: return@withLock
                 val lines = dao.getLinesForFileSync(fileId)
@@ -1184,14 +1184,14 @@ class CalculatorViewModel(
     }
 
     suspend fun doesFileExist(name: String, excludeId: Long? = null): Boolean {
-        return withContext(Dispatchers.IO) {
+        return withContext(ioDispatcher) {
             if (excludeId == null) dao.doesFileExist(name) else dao.doesFileExist(name, excludeId)
         }
     }
 
     fun togglePinFile(fileId: Long) {
         viewModelScope.launch {
-            val success = withContext(Dispatchers.IO) {
+            val success = withContext(ioDispatcher) {
                 dao.togglePinFileIfAllowed(fileId, Constants.MAX_PINNED_FILES)
             }
             if (!success) {
@@ -1246,7 +1246,7 @@ class CalculatorViewModel(
     }
 
     suspend fun copyFileToClipboard(context: Context, fileId: Long): Result<String> {
-        return withContext(Dispatchers.IO) {
+        return withContext(ioDispatcher) {
             try {
                 val lines = dao.getLinesForFileSync(fileId)
                 val content = FileUtils.formatFileContent(lines, precision.value)

--- a/app/src/test/java/com/vishaltelangre/nerdcalci/core/MathEngineTest.kt
+++ b/app/src/test/java/com/vishaltelangre/nerdcalci/core/MathEngineTest.kt
@@ -380,6 +380,7 @@ class MathEngineTest {
 
     @Test
     fun `all numeral multiplier aliases evaluate correctly`() = testCalculate(
+        "5 dozen", "raw(5 dozen)", "5 dozens", "raw(5 dozens)",
         "5 hundred", "raw(5 hundred)", "5 hundreds", "raw(5 hundreds)",
         "5 thousand", "raw(5 thousand)", "5 thousands", "raw(5 thousands)",
         "5 lakh", "raw(5 lakh)", "5 lakhs", "raw(5 lakhs)",
@@ -390,50 +391,55 @@ class MathEngineTest {
         "1 quadrillion", "raw(1 quadrillion)", "1 quadrillions", "raw(1 quadrillions)",
         "1 quintillion", "raw(1 quintillion)", "1 quintillions", "raw(1 quintillions)"
     ) { result ->
-        assertEquals("500.0", result[0].result)
-        assertEquals("500", result[1].result)
-        assertEquals("500.0", result[2].result)
-        assertEquals("500", result[3].result)
+        assertEquals("60.0", result[0].result)
+        assertEquals("60", result[1].result)
+        assertEquals("60.0", result[2].result)
+        assertEquals("60", result[3].result)
 
-        assertEquals("5000.0", result[4].result)
-        assertEquals("5000", result[5].result)
-        assertEquals("5000.0", result[6].result)
-        assertEquals("5000", result[7].result)
+        assertEquals("500.0", result[4].result)
+        assertEquals("500", result[5].result)
+        assertEquals("500.0", result[6].result)
+        assertEquals("500", result[7].result)
 
-        assertEquals("500000.0", result[8].result)
-        assertEquals("500000", result[9].result)
-        assertEquals("500000.0", result[10].result)
-        assertEquals("500000", result[11].result)
+        assertEquals("5000.0", result[8].result)
+        assertEquals("5000", result[9].result)
+        assertEquals("5000.0", result[10].result)
+        assertEquals("5000", result[11].result)
 
-        assertEquals("5000000.0", result[12].result)
-        assertEquals("5000000", result[13].result)
-        assertEquals("5000000.0", result[14].result)
-        assertEquals("5000000", result[15].result)
+        assertEquals("500000.0", result[12].result)
+        assertEquals("500000", result[13].result)
+        assertEquals("500000.0", result[14].result)
+        assertEquals("500000", result[15].result)
 
-        assertEquals("50000000.0", result[16].result)
-        assertEquals("50000000", result[17].result)
-        assertEquals("50000000.0", result[18].result)
-        assertEquals("50000000", result[19].result)
+        assertEquals("5000000.0", result[16].result)
+        assertEquals("5000000", result[17].result)
+        assertEquals("5000000.0", result[18].result)
+        assertEquals("5000000", result[19].result)
 
-        assertEquals("5000000000.0", result[20].result)
-        assertEquals("5000000000", result[21].result)
-        assertEquals("5000000000.0", result[22].result)
-        assertEquals("5000000000", result[23].result)
+        assertEquals("50000000.0", result[20].result)
+        assertEquals("50000000", result[21].result)
+        assertEquals("50000000.0", result[22].result)
+        assertEquals("50000000", result[23].result)
 
-        assertEquals("5000000000000.0", result[24].result)
-        assertEquals("5000000000000", result[25].result)
-        assertEquals("5000000000000.0", result[26].result)
-        assertEquals("5000000000000", result[27].result)
+        assertEquals("5000000000.0", result[24].result)
+        assertEquals("5000000000", result[25].result)
+        assertEquals("5000000000.0", result[26].result)
+        assertEquals("5000000000", result[27].result)
 
-        assertEquals("1.0E15", result[28].result)
-        assertEquals("1000000000000000", result[29].result)
-        assertEquals("1.0E15", result[30].result)
-        assertEquals("1000000000000000", result[31].result)
+        assertEquals("5000000000000.0", result[28].result)
+        assertEquals("5000000000000", result[29].result)
+        assertEquals("5000000000000.0", result[30].result)
+        assertEquals("5000000000000", result[31].result)
 
-        assertEquals("1.0E18", result[32].result)
-        assertEquals("1000000000000000000", result[33].result)
-        assertEquals("1.0E18", result[34].result)
-        assertEquals("1000000000000000000", result[35].result)
+        assertEquals("1.0E15", result[32].result)
+        assertEquals("1000000000000000", result[33].result)
+        assertEquals("1.0E15", result[34].result)
+        assertEquals("1000000000000000", result[35].result)
+
+        assertEquals("1.0E18", result[36].result)
+        assertEquals("1000000000000000000", result[37].result)
+        assertEquals("1.0E18", result[38].result)
+        assertEquals("1000000000000000000", result[39].result)
     }
 
     @Test

--- a/app/src/test/java/com/vishaltelangre/nerdcalci/core/MixedUnitUsageTest.kt
+++ b/app/src/test/java/com/vishaltelangre/nerdcalci/core/MixedUnitUsageTest.kt
@@ -173,17 +173,49 @@ class MixedUnitUsageTest {
 
     @Test
     fun `multiply speed by time`() {
-        testCalculate("10 mps * 5 s", "30 kmh * 2 h") { result ->
+        testCalculate(
+            "10 mps * 5 s",
+            "5 s * 10 mps",
+            "10 kmh * 5 h",
+            "5 h * 10 kmh",
+            "10 mph * 5 h",
+            "5 h * 10 mph",
+            "10 kn * 5 h",
+            "5 h * 10 kn",
+            "10 fps * 5 s",
+            "5 s * 10 fps",
+            "1 speed of light * 10 s",
+            "10 s * 1 speed of light"
+        ) { result ->
             assertEquals("50.0 m", result[0].result)
-            assertEquals("60.0 km", result[1].result)
+            assertEquals("50.0 m", result[1].result)
+            assertEquals("50.0 km", result[2].result)
+            assertEquals("50.0 km", result[3].result)
+            assertEquals("50.0 mi", result[4].result)
+            assertEquals("50.0 mi", result[5].result)
+            assertEquals("49.99995680345572354211663066954644 NM", result[6].result) // Floating point error
+            assertEquals("49.99995680345572354211663066954644 NM", result[7].result)
+            assertEquals("50.0 ft", result[8].result)
+            assertEquals("50.0 ft", result[9].result)
+            assertEquals("2997924580.0 m", result[10].result)
+            assertEquals("2997924580.0 m", result[11].result)
         }
     }
 
     @Test
     fun `divide length by time`() {
-        testCalculate("50 m / 10 s", "30 km / 2 h") { result ->
-            assertEquals("5.0 mps", result[0].result)
-            assertEquals("15.0 kmh", result[1].result)
+        testCalculate(
+            "10 m / 5 s",
+            "10 km / 5 h",
+            "10 mi / 5 h",
+            "10 NM / 5 h",
+            "10 ft / 5 s"
+        ) { result ->
+            assertEquals("2.0 mps", result[0].result)
+            assertEquals("2.0 kmh", result[1].result)
+            assertEquals("2.0 mph", result[2].result)
+            assertEquals("2.000001727863263812754913827139376 kn", result[3].result) // Floating point error
+            assertEquals("2.0 fps", result[4].result)
         }
     }
 }

--- a/app/src/test/java/com/vishaltelangre/nerdcalci/core/MixedUnitUsageTest.kt
+++ b/app/src/test/java/com/vishaltelangre/nerdcalci/core/MixedUnitUsageTest.kt
@@ -1,9 +1,35 @@
 package com.vishaltelangre.nerdcalci.core
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.*
 import org.junit.Test
+import com.vishaltelangre.nerdcalci.core.testCalculate
+import com.vishaltelangre.nerdcalci.core.assertError
 
 class MixedUnitUsageTest {
+
+    private val lengthSymbols = UnitConverter.UNITS
+        .filter { it.category == UnitCategory.LENGTH }
+        .flatMap { it.symbols }
+
+    private val timeSymbols = UnitConverter.UNITS
+        .filter { it.category == UnitCategory.TIME }
+        .flatMap { it.symbols }
+
+    private val speedSymbols = UnitConverter.UNITS
+        .filter { it.category == UnitCategory.SPEED }
+        .flatMap { it.symbols }
+
+    private fun isSpeedUnit(result: String): Boolean {
+        return speedSymbols.any { result.endsWith(it) || result.contains(" $it") }
+    }
+
+    private fun isLengthUnit(result: String): Boolean {
+        return lengthSymbols.any { result.endsWith(it) || result.contains(" $it") }
+    }
+
+    private fun isTimeUnit(result: String): Boolean {
+        return timeSymbols.any { result.endsWith(it) || result.contains(" $it") }
+    }
 
     @Test
     fun `basic mixed unit addition fails`() {
@@ -128,9 +154,24 @@ class MixedUnitUsageTest {
 
     @Test
     fun `scalar mixed with unitless passes`() {
-        testCalculate("30 + 1 thousand", "1 thousand + 30") { result ->
+        testCalculate(
+            "30 + 1 thousand",
+            "1 thousand + 30",
+            "4 dozen",
+            "raw(4 dozen)",
+            "4 dozens",
+            "raw(4 dozens)",
+            "1 dozen + 1",
+            "raw(1 dozen + 1)"
+        ) { result ->
             assertEquals("1030.0", result[0].result)
             assertEquals("1030.0", result[1].result)
+            assertEquals("48.0", result[2].result)
+            assertEquals("48", result[3].result)
+            assertEquals("48.0", result[4].result)
+            assertEquals("48", result[5].result)
+            assertEquals("13.0", result[6].result)
+            assertEquals("13", result[7].result)
         }
     }
 
@@ -193,8 +234,9 @@ class MixedUnitUsageTest {
             assertEquals("50.0 km", result[3].result)
             assertEquals("50.0 mi", result[4].result)
             assertEquals("50.0 mi", result[5].result)
-            assertEquals("49.99999999999999999999999999999999 NM", result[6].result) // Floating point error
-            assertEquals("49.99999999999999999999999999999999 NM", result[7].result)
+            // Near 50.0 NM (handles floating point discrepancies)
+            assertResultNear("50.0 NM", result[6].result)
+            assertResultNear("50.0 NM", result[7].result)
             assertEquals("50.0 ft", result[8].result)
             assertEquals("50.0 ft", result[9].result)
             assertEquals("2997924580.0 m", result[10].result)
@@ -253,7 +295,7 @@ class MixedUnitUsageTest {
             assertEquals("2.0 mps", result[0].result)
             assertEquals("2.0 kmh", result[1].result)
             assertEquals("2.0 mph", result[2].result)
-            assertEquals("2.0 kn", result[3].result) // Floating point error
+            assertResultNear("2.0 kn", result[3].result)
             assertEquals("2.0 fps", result[4].result)
         }
     }
@@ -292,8 +334,8 @@ class MixedUnitUsageTest {
             assertEquals("3.0 fps", result[9].result)
             assertEquals("1.0 mph", result[10].result)
             assertEquals("0.125 mph", result[11].result)
-            assertEquals("0.0009874730021598272138228941684665228 kn", result[12].result)
-            assertEquals("1.0 kn", result[13].result) // Floating point error
+            assertResultNear("0.000987473 kn", result[12].result)
+            assertResultNear("1.0 kn", result[13].result)
             assertEquals("9.4607304725808E15 mps", result[14].result)
             assertEquals("1.0E-10 mps", result[15].result)
             assertEquals("1.0E-12 mps", result[16].result)
@@ -337,6 +379,61 @@ class MixedUnitUsageTest {
             assertEquals("3.16887385068114309645621034629707E-11 mps", result[13].result)
             assertEquals("10.0 mps", result[14].result)
             assertEquals("100.0 mps", result[15].result)
+        }
+    }
+
+    private fun assertResultNear(expected: String, actual: String, tolerance: Double = 1e-9) {
+        val expectedParts = expected.split(" ")
+        val actualParts = actual.split(" ")
+
+        assertEquals("Unit mismatch", expectedParts.last(), actualParts.last())
+
+        val expectedVal = expectedParts.first().toDouble()
+        val actualVal = actualParts.first().toDouble()
+
+        assertEquals("Value too far from expected", expectedVal, actualVal, tolerance)
+    }
+
+    @Test
+    fun `length divided by time yields speed results`() {
+        lengthSymbols.forEach { l ->
+            timeSymbols.forEach { t ->
+                testCalculate("1 $l / 1 $t") { result ->
+                    assertFalse("Division failed for 1 $l / 1 $t", result[0].result == "Err")
+                    assertTrue("Result for 1 $l / 1 $t is not a speed unit: ${result[0].result}",
+                        isSpeedUnit(result[0].result))
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `speed multiplied by time yields length results`() {
+        speedSymbols.forEach { s ->
+            timeSymbols.forEach { t ->
+                testCalculate("1 $s * 1 $t", "1 $t * 1 $s") { result ->
+                    assertFalse("Multiplication failed for 1 $s * 1 $t", result[0].result == "Err")
+                    assertTrue("Result for 1 $s * 1 $t is not a length unit: ${result[0].result}",
+                        isLengthUnit(result[0].result))
+
+                    assertFalse("Multiplication failed for 1 $t * 1 $s", result[1].result == "Err")
+                    assertTrue("Result for 1 $t * 1 $s is not a length unit: ${result[1].result}",
+                        isLengthUnit(result[1].result))
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `length divided by speed yields time results`() {
+        lengthSymbols.forEach { l ->
+            speedSymbols.forEach { s ->
+                testCalculate("1 $l / 1 $s") { result ->
+                    assertFalse("Division failed for 1 $l / 1 $s", result[0].result == "Err")
+                    assertTrue("Result for 1 $l / 1 $s is not a time unit: ${result[0].result}",
+                        isTimeUnit(result[0].result))
+                }
+            }
         }
     }
 }

--- a/app/src/test/java/com/vishaltelangre/nerdcalci/core/MixedUnitUsageTest.kt
+++ b/app/src/test/java/com/vishaltelangre/nerdcalci/core/MixedUnitUsageTest.kt
@@ -193,8 +193,8 @@ class MixedUnitUsageTest {
             assertEquals("50.0 km", result[3].result)
             assertEquals("50.0 mi", result[4].result)
             assertEquals("50.0 mi", result[5].result)
-            assertEquals("49.99995680345572354211663066954644 NM", result[6].result) // Floating point error
-            assertEquals("49.99995680345572354211663066954644 NM", result[7].result)
+            assertEquals("49.99999999999999999999999999999999 NM", result[6].result) // Floating point error
+            assertEquals("49.99999999999999999999999999999999 NM", result[7].result)
             assertEquals("50.0 ft", result[8].result)
             assertEquals("50.0 ft", result[9].result)
             assertEquals("2997924580.0 m", result[10].result)
@@ -253,7 +253,7 @@ class MixedUnitUsageTest {
             assertEquals("2.0 mps", result[0].result)
             assertEquals("2.0 kmh", result[1].result)
             assertEquals("2.0 mph", result[2].result)
-            assertEquals("2.000001727863263812754913827139376 kn", result[3].result) // Floating point error
+            assertEquals("2.0 kn", result[3].result) // Floating point error
             assertEquals("2.0 fps", result[4].result)
         }
     }
@@ -292,8 +292,8 @@ class MixedUnitUsageTest {
             assertEquals("3.0 fps", result[9].result)
             assertEquals("1.0 mph", result[10].result)
             assertEquals("0.125 mph", result[11].result)
-            assertEquals("0.0009874738552689894332522101530973245 kn", result[12].result)
-            assertEquals("1.000000863931631906377456913569688 kn", result[13].result) // Floating point error
+            assertEquals("0.0009874730021598272138228941684665228 kn", result[12].result)
+            assertEquals("1.0 kn", result[13].result) // Floating point error
             assertEquals("9.4607304725808E15 mps", result[14].result)
             assertEquals("1.0E-10 mps", result[15].result)
             assertEquals("1.0E-12 mps", result[16].result)

--- a/app/src/test/java/com/vishaltelangre/nerdcalci/core/MixedUnitUsageTest.kt
+++ b/app/src/test/java/com/vishaltelangre/nerdcalci/core/MixedUnitUsageTest.kt
@@ -203,6 +203,45 @@ class MixedUnitUsageTest {
     }
 
     @Test
+    fun `multiply speed by non-matching time`() {
+        testCalculate(
+            "1 mps * 1 s",
+            "1 mps * 1 ms",
+            "1 mps * 1 µs",
+            "1 mps * 1 ns",
+            "1 mps * 1 min",
+            "1 mps * 1 h",
+            "1 mps * 1 d",
+            "1 mps * 1 wk",
+            "1 mps * 1 mo",
+            "1 mps * 1 yr",
+            "1 mps * 1 lustrum",
+            "1 mps * 1 decade",
+            "1 mps * 1 century",
+            "1 mps * 1 millennium",
+            "1 mps * 1 decisecond",
+            "1 mps * 1 centisecond"
+        ) { result ->
+            assertEquals("1.0 m", result[0].result)
+            assertEquals("0.001 m", result[1].result)
+            assertEquals("1.0E-6 m", result[2].result)
+            assertEquals("1.0E-9 m", result[3].result)
+            assertEquals("60.0 m", result[4].result)
+            assertEquals("3600.0 m", result[5].result)
+            assertEquals("86400.0 m", result[6].result)
+            assertEquals("604800.0 m", result[7].result)
+            assertEquals("2629746.0 m", result[8].result)
+            assertEquals("31556952.0 m", result[9].result)
+            assertEquals("157784760.0 m", result[10].result)
+            assertEquals("315569520.0 m", result[11].result)
+            assertEquals("3155695200.0 m", result[12].result)
+            assertEquals("31556952000.0 m", result[13].result)
+            assertEquals("0.1 m", result[14].result)
+            assertEquals("0.01 m", result[15].result)
+        }
+    }
+
+    @Test
     fun `divide length by time`() {
         testCalculate(
             "10 m / 5 s",
@@ -216,6 +255,88 @@ class MixedUnitUsageTest {
             assertEquals("2.0 mph", result[2].result)
             assertEquals("2.000001727863263812754913827139376 kn", result[3].result) // Floating point error
             assertEquals("2.0 fps", result[4].result)
+        }
+    }
+
+    @Test
+    fun `divide non-matching length by time`() {
+        testCalculate(
+            "1 nm / 1 s",
+            "1 µm / 1 s",
+            "1 mm / 1 s",
+            "1 cm / 1 s",
+            "1 dm / 1 s",
+            "1 m / 1 s",
+            "1 km / 1 h",
+            "1 inch / 1 s",
+            "1 ft / 1 s",
+            "1 yd / 1 s",
+            "1 mi / 1 h",
+            "1 fur / 1 h",
+            "1 ftm / 1 h",
+            "1 NM / 1 h",
+            "1 ly / 1 s",
+            "1 Å / 1 s",
+            "1 pm / 1 s",
+            "1 au / 1 s"
+        ) {result ->
+            assertEquals("1.0E-9 mps", result[0].result)
+            assertEquals("1.0E-6 mps", result[1].result)
+            assertEquals("0.001 mps", result[2].result)
+            assertEquals("0.01 mps", result[3].result)
+            assertEquals("0.1 mps", result[4].result)
+            assertEquals("1.0 mps", result[5].result)
+            assertEquals("1.0 kmh", result[6].result)
+            assertEquals("0.08333333333333333333333333333333333 fps", result[7].result)
+            assertEquals("1.0 fps", result[8].result)
+            assertEquals("3.0 fps", result[9].result)
+            assertEquals("1.0 mph", result[10].result)
+            assertEquals("0.125 mph", result[11].result)
+            assertEquals("0.0009874738552689894332522101530973245 kn", result[12].result)
+            assertEquals("1.000000863931631906377456913569688 kn", result[13].result) // Floating point error
+            assertEquals("9.4607304725808E15 mps", result[14].result)
+            assertEquals("1.0E-10 mps", result[15].result)
+            assertEquals("1.0E-12 mps", result[16].result)
+            assertEquals("149597870700.0 mps", result[17].result)
+        }
+    }
+
+    @Test
+    fun `divide length by non-matching time`() {
+        testCalculate(
+            "1 m / 1 s",
+            "1 m / 1 ms",
+            "1 m / 1 µs",
+            "1 m / 1 ns",
+            "1 m / 1 min",
+            "1 m / 1 hr",
+            "1 m / 1 d",
+            "1 m / 1 wk",
+            "1 m / 1 mo",
+            "1 m / 1 yr",
+            "1 m / 1 lustrum",
+            "1 m / 1 decade",
+            "1 m / 1 century",
+            "1 m / 1 millennium",
+            "1 m / 1 ds",
+            "1 m / 1 cs"
+        ) { result ->
+            assertEquals("1.0 mps", result[0].result)
+            assertEquals("1000.0 mps", result[1].result)
+            assertEquals("1000000.0 mps", result[2].result)
+            assertEquals("1000000000.0 mps", result[3].result)
+            assertEquals("0.01666666666666666666666666666666667 mps", result[4].result)
+            assertEquals("0.0002777777777777777777777777777777778 mps", result[5].result)
+            assertEquals("0.00001157407407407407407407407407407407 mps", result[6].result)
+            assertEquals("1.653439153439153439153439153439153E-6 mps", result[7].result)
+            assertEquals("3.802648620817371715747452415556483E-7 mps", result[8].result)
+            assertEquals("3.16887385068114309645621034629707E-8 mps", result[9].result)
+            assertEquals("6.337747701362286192912420692594139E-9 mps", result[10].result)
+            assertEquals("3.16887385068114309645621034629707E-9 mps", result[11].result)
+            assertEquals("3.16887385068114309645621034629707E-10 mps", result[12].result)
+            assertEquals("3.16887385068114309645621034629707E-11 mps", result[13].result)
+            assertEquals("10.0 mps", result[14].result)
+            assertEquals("100.0 mps", result[15].result)
         }
     }
 }

--- a/app/src/test/java/com/vishaltelangre/nerdcalci/core/MixedUnitUsageTest.kt
+++ b/app/src/test/java/com/vishaltelangre/nerdcalci/core/MixedUnitUsageTest.kt
@@ -170,4 +170,20 @@ class MixedUnitUsageTest {
             assertEquals("10.0 km", result[2].result)
         }
     }
+
+    @Test
+    fun `multiply speed by time`() {
+        testCalculate("10 mps * 5 s", "30 kmh * 2 h") { result ->
+            assertEquals("50.0 m", result[0].result)
+            assertEquals("60.0 km", result[1].result)
+        }
+    }
+
+    @Test
+    fun `divide length by time`() {
+        testCalculate("50 m / 10 s", "30 km / 2 h") { result ->
+            assertEquals("5.0 mps", result[0].result)
+            assertEquals("15.0 kmh", result[1].result)
+        }
+    }
 }

--- a/app/src/test/java/com/vishaltelangre/nerdcalci/core/UnitConversionStaticTest.kt
+++ b/app/src/test/java/com/vishaltelangre/nerdcalci/core/UnitConversionStaticTest.kt
@@ -3181,14 +3181,40 @@ class UnitConversionStaticTest {
         "10 J in btu",
         "10 GJ in J",
         "10 J in GJ",
+        "10 gigajoule in J",
+        "10 J in gigajoule",
         "10 gigajoules in J",
         "10 J in gigajoules",
         "10 tTNT in J",
         "10 J in tTNT",
+        "10 ton of TNT in J",
+        "10 J in ton of TNT",
+        "10 tons of TNT in J",
+        "10 J in tons of TNT",
+        "10 tonne of TNT in J",
+        "10 J in tonne of TNT",
+        "10 tonnes of TNT in J",
+        "10 J in tonnes of TNT",
         "10 ktTNT in J",
         "10 J in ktTNT",
+        "10 kiloton of TNT in J",
+        "10 J in kiloton of TNT",
+        "10 kilotons of TNT in J",
+        "10 J in kilotons of TNT",
+        "10 kilotonne of TNT in J",
+        "10 J in kilotonne of TNT",
+        "10 kilotonnes of TNT in J",
+        "10 J in kilotonnes of TNT",
         "10 MtTNT in J",
-        "10 J in MtTNT"
+        "10 J in MtTNT",
+        "10 megaton of TNT in J",
+        "10 J in megaton of TNT",
+        "10 megatons of TNT in J",
+        "10 J in megatons of TNT",
+        "10 megatonne of TNT in J",
+        "10 J in megatonne of TNT",
+        "10 megatonnes of TNT in J",
+        "10 J in megatonnes of TNT"
     ) { result ->
         val val0 = result[0].result.substringBefore(' ').toDoubleOrNull()
         assertNotNull(val0)
@@ -3372,34 +3398,115 @@ class UnitConversionStaticTest {
         assertEquals("J to btu", 0.009478171203133172, val59!!, 0.05)
         val val60 = result[60].result.substringBefore(' ').toDoubleOrNull()
         assertNotNull(val60)
-        assertEquals("GJ to J", 10000000000.0, val60!!, 0.05)
+        assertEquals("GJ to J", 1.0E10, val60!!, 0.05)
         val val61 = result[61].result.substringBefore(' ').toDoubleOrNull()
         assertNotNull(val61)
-        assertEquals("J to GJ", 0.00000001, val61!!, 0.05)
+        assertEquals("J to GJ", 1.0E-8, val61!!, 0.05)
         val val62 = result[62].result.substringBefore(' ').toDoubleOrNull()
         assertNotNull(val62)
-        assertEquals("gigajoules to J", 10000000000.0, val62!!, 0.05)
+        assertEquals("gigajoule to J", 1.0E10, val62!!, 0.05)
         val val63 = result[63].result.substringBefore(' ').toDoubleOrNull()
         assertNotNull(val63)
-        assertEquals("J to gigajoules", 0.00000001, val63!!, 0.05)
+        assertEquals("J to gigajoule", 1.0E-8, val63!!, 0.05)
         val val64 = result[64].result.substringBefore(' ').toDoubleOrNull()
         assertNotNull(val64)
-        assertEquals("tTNT to J", 41840000000.0, val64!!, 0.05)
+        assertEquals("gigajoules to J", 1.0E10, val64!!, 0.05)
         val val65 = result[65].result.substringBefore(' ').toDoubleOrNull()
         assertNotNull(val65)
-        assertEquals("J to tTNT", 2.3900573614E-10, val65!!, 0.05)
+        assertEquals("J to gigajoules", 1.0E-8, val65!!, 0.05)
+
         val val66 = result[66].result.substringBefore(' ').toDoubleOrNull()
         assertNotNull(val66)
-        assertEquals("ktTNT to J", 41840000000000.0, val66!!, 0.05)
+        assertEquals("tTNT to J", 4.184E10, val66!!, 0.05)
         val val67 = result[67].result.substringBefore(' ').toDoubleOrNull()
         assertNotNull(val67)
-        assertEquals("J to ktTNT", 2.3900573614E-13, val67!!, 0.05)
+        assertEquals("J to tTNT", 2.3900573614E-9, val67!!, 0.05)
         val val68 = result[68].result.substringBefore(' ').toDoubleOrNull()
         assertNotNull(val68)
-        assertEquals("MtTNT to J", 41840000000000000.0, val68!!, 0.05)
+        assertEquals("ton of TNT to J", 4.184E10, val68!!, 0.05)
         val val69 = result[69].result.substringBefore(' ').toDoubleOrNull()
         assertNotNull(val69)
-        assertEquals("J to MtTNT", 2.3900573614E-16, val69!!, 0.05)
+        assertEquals("J to ton of TNT", 2.3900573614E-9, val69!!, 0.05)
+        val val70 = result[70].result.substringBefore(' ').toDoubleOrNull()
+        assertNotNull(val70)
+        assertEquals("tons of TNT to J", 4.184E10, val70!!, 0.05)
+        val val71 = result[71].result.substringBefore(' ').toDoubleOrNull()
+        assertNotNull(val71)
+        assertEquals("J to tons of TNT", 2.3900573614E-9, val71!!, 0.05)
+        val val72 = result[72].result.substringBefore(' ').toDoubleOrNull()
+        assertNotNull(val72)
+        assertEquals("tonne of TNT to J", 4.184E10, val72!!, 0.05)
+        val val73 = result[73].result.substringBefore(' ').toDoubleOrNull()
+        assertNotNull(val73)
+        assertEquals("J to tonne of TNT", 2.3900573614E-9, val73!!, 0.05)
+        val val74 = result[74].result.substringBefore(' ').toDoubleOrNull()
+        assertNotNull(val74)
+        assertEquals("tonnes of TNT to J", 4.184E10, val74!!, 0.05)
+        val val75 = result[75].result.substringBefore(' ').toDoubleOrNull()
+        assertNotNull(val75)
+        assertEquals("J to tonnes of TNT", 2.3900573614E-9, val75!!, 0.05)
+
+        val val76 = result[76].result.substringBefore(' ').toDoubleOrNull()
+        assertNotNull(val76)
+        assertEquals("ktTNT to J", 4.184E13, val76!!, 0.05)
+        val val77 = result[77].result.substringBefore(' ').toDoubleOrNull()
+        assertNotNull(val77)
+        assertEquals("J to ktTNT", 2.3900573614E-12, val77!!, 0.05)
+        val val78 = result[78].result.substringBefore(' ').toDoubleOrNull()
+        assertNotNull(val78)
+        assertEquals("kiloton of TNT to J", 4.184E13, val78!!, 0.05)
+        val val79 = result[79].result.substringBefore(' ').toDoubleOrNull()
+        assertNotNull(val79)
+        assertEquals("J to kiloton of TNT", 2.3900573614E-12, val79!!, 0.05)
+        val val80 = result[80].result.substringBefore(' ').toDoubleOrNull()
+        assertNotNull(val80)
+        assertEquals("kilotons of TNT to J", 4.184E13, val80!!, 0.05)
+        val val81 = result[81].result.substringBefore(' ').toDoubleOrNull()
+        assertNotNull(val81)
+        assertEquals("J to kilotons of TNT", 2.3900573614E-12, val81!!, 0.05)
+        val val82 = result[82].result.substringBefore(' ').toDoubleOrNull()
+        assertNotNull(val82)
+        assertEquals("kilotonne of TNT to J", 4.184E13, val82!!, 0.05)
+        val val83 = result[83].result.substringBefore(' ').toDoubleOrNull()
+        assertNotNull(val83)
+        assertEquals("J to kilotonne of TNT", 2.3900573614E-12, val83!!, 0.05)
+        val val84 = result[84].result.substringBefore(' ').toDoubleOrNull()
+        assertNotNull(val84)
+        assertEquals("kilotonnes of TNT to J", 4.184E13, val84!!, 0.05)
+        val val85 = result[85].result.substringBefore(' ').toDoubleOrNull()
+        assertNotNull(val85)
+        assertEquals("J to kilotonnes of TNT", 2.3900573614E-12, val85!!, 0.05)
+
+        val val86 = result[86].result.substringBefore(' ').toDoubleOrNull()
+        assertNotNull(val86)
+        assertEquals("MtTNT to J", 4.184E16, val86!!, 0.05)
+        val val87 = result[87].result.substringBefore(' ').toDoubleOrNull()
+        assertNotNull(val87)
+        assertEquals("J to MtTNT", 2.3900573614E-15, val87!!, 0.05)
+        val val88 = result[88].result.substringBefore(' ').toDoubleOrNull()
+        assertNotNull(val88)
+        assertEquals("megaton of TNT to J", 4.184E16, val88!!, 0.05)
+        val val89 = result[89].result.substringBefore(' ').toDoubleOrNull()
+        assertNotNull(val89)
+        assertEquals("J to megaton of TNT", 2.3900573614E-15, val89!!, 0.05)
+        val val90 = result[90].result.substringBefore(' ').toDoubleOrNull()
+        assertNotNull(val90)
+        assertEquals("megatons of TNT to J", 4.184E16, val90!!, 0.05)
+        val val91 = result[91].result.substringBefore(' ').toDoubleOrNull()
+        assertNotNull(val91)
+        assertEquals("J to megatons of TNT", 2.3900573614E-15, val91!!, 0.05)
+        val val92 = result[92].result.substringBefore(' ').toDoubleOrNull()
+        assertNotNull(val92)
+        assertEquals("megatonne of TNT to J", 4.184E16, val92!!, 0.05)
+        val val93 = result[93].result.substringBefore(' ').toDoubleOrNull()
+        assertNotNull(val93)
+        assertEquals("J to megatonne of TNT", 2.3900573614E-15, val93!!, 0.05)
+        val val94 = result[94].result.substringBefore(' ').toDoubleOrNull()
+        assertNotNull(val94)
+        assertEquals("megatonnes of TNT to J", 4.184E16, val94!!, 0.05)
+        val val95 = result[95].result.substringBefore(' ').toDoubleOrNull()
+        assertNotNull(val95)
+        assertEquals("J to megatonnes of TNT", 2.3900573614E-15, val95!!, 0.05)
     }
 
     @Test

--- a/app/src/test/java/com/vishaltelangre/nerdcalci/core/UnitConversionStaticTest.kt
+++ b/app/src/test/java/com/vishaltelangre/nerdcalci/core/UnitConversionStaticTest.kt
@@ -3399,7 +3399,7 @@ class UnitConversionStaticTest {
         assertEquals("MtTNT to J", 41840000000000000.0, val68!!, 0.05)
         val val69 = result[69].result.substringBefore(' ').toDoubleOrNull()
         assertNotNull(val69)
-        assertEquals("J to tTNT", 2.3900573614E-16, val69!!, 0.05)
+        assertEquals("J to MtTNT", 2.3900573614E-16, val69!!, 0.05)
     }
 
     @Test

--- a/app/src/test/java/com/vishaltelangre/nerdcalci/core/UnitConversionStaticTest.kt
+++ b/app/src/test/java/com/vishaltelangre/nerdcalci/core/UnitConversionStaticTest.kt
@@ -3178,7 +3178,17 @@ class UnitConversionStaticTest {
         "10 BTU in J",
         "10 J in BTU",
         "10 btu in J",
-        "10 J in btu"
+        "10 J in btu",
+        "10 GJ in J",
+        "10 J in GJ",
+        "10 gigajoules in J",
+        "10 J in gigajoules",
+        "10 tTNT in J",
+        "10 J in tTNT",
+        "10 ktTNT in J",
+        "10 J in ktTNT",
+        "10 MtTNT in J",
+        "10 J in MtTNT"
     ) { result ->
         val val0 = result[0].result.substringBefore(' ').toDoubleOrNull()
         assertNotNull(val0)
@@ -3360,6 +3370,36 @@ class UnitConversionStaticTest {
         val val59 = result[59].result.substringBefore(' ').toDoubleOrNull()
         assertNotNull(val59)
         assertEquals("J to btu", 0.009478171203133172, val59!!, 0.05)
+        val val60 = result[60].result.substringBefore(' ').toDoubleOrNull()
+        assertNotNull(val60)
+        assertEquals("GJ to J", 10000000000.0, val60!!, 0.05)
+        val val61 = result[61].result.substringBefore(' ').toDoubleOrNull()
+        assertNotNull(val61)
+        assertEquals("J to GJ", 0.00000001, val61!!, 0.05)
+        val val62 = result[62].result.substringBefore(' ').toDoubleOrNull()
+        assertNotNull(val62)
+        assertEquals("gigajoules to J", 10000000000.0, val62!!, 0.05)
+        val val63 = result[63].result.substringBefore(' ').toDoubleOrNull()
+        assertNotNull(val63)
+        assertEquals("J to gigajoules", 0.00000001, val63!!, 0.05)
+        val val64 = result[64].result.substringBefore(' ').toDoubleOrNull()
+        assertNotNull(val64)
+        assertEquals("tTNT to J", 41840000000.0, val64!!, 0.05)
+        val val65 = result[65].result.substringBefore(' ').toDoubleOrNull()
+        assertNotNull(val65)
+        assertEquals("J to tTNT", 2.3900573614E-10, val65!!, 0.05)
+        val val66 = result[66].result.substringBefore(' ').toDoubleOrNull()
+        assertNotNull(val66)
+        assertEquals("ktTNT to J", 41840000000000.0, val66!!, 0.05)
+        val val67 = result[67].result.substringBefore(' ').toDoubleOrNull()
+        assertNotNull(val67)
+        assertEquals("J to ktTNT", 2.3900573614E-13, val67!!, 0.05)
+        val val68 = result[68].result.substringBefore(' ').toDoubleOrNull()
+        assertNotNull(val68)
+        assertEquals("MtTNT to J", 41840000000000000.0, val68!!, 0.05)
+        val val69 = result[69].result.substringBefore(' ').toDoubleOrNull()
+        assertNotNull(val69)
+        assertEquals("J to tTNT", 2.3900573614E-16, val69!!, 0.05)
     }
 
     @Test

--- a/app/src/test/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorViewModelTest.kt
+++ b/app/src/test/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorViewModelTest.kt
@@ -20,7 +20,7 @@ import org.junit.rules.TestWatcher
 import org.junit.runner.Description
 
 class MainDispatcherRule(
-    val testDispatcher: TestDispatcher = UnconfinedTestDispatcher()
+    val testDispatcher: TestDispatcher = UnconfinedTestDispatcher(TestCoroutineScheduler())
 ) : TestWatcher() {
     override fun starting(description: Description) {
         Dispatchers.setMain(testDispatcher)
@@ -48,7 +48,7 @@ class CalculatorViewModelTest {
         every { Log.w(any<String>(), any<String>()) } returns 0
 
         fakeDao = FakeCalculatorDao()
-        viewModel = CalculatorViewModel(fakeDao)
+        viewModel = CalculatorViewModel(fakeDao, ioDispatcher = mainDispatcherRule.testDispatcher)
     }
 
     @After

--- a/app/src/test/java/com/vishaltelangre/nerdcalci/ui/calculator/LockFeatureTest.kt
+++ b/app/src/test/java/com/vishaltelangre/nerdcalci/ui/calculator/LockFeatureTest.kt
@@ -46,7 +46,7 @@ class LockFeatureTest {
         every { FileUtils.calculateHash(any<String>()) } returns "mock-hash"
 
         fakeDao = FakeCalculatorDao()
-        viewModel = CalculatorViewModel(fakeDao, ioDispatcher = UnconfinedTestDispatcher())
+        viewModel = CalculatorViewModel(fakeDao, ioDispatcher = mainDispatcherRule.testDispatcher)
     }
 
     @After


### PR DESCRIPTION
### New units
- Four new large energy units - gigajoules and tons, kilotons and megatons of TNT equivalent. The conversion for those is from Wikipedia
- Dozen - Scalar that makes counting eggs easier

### Unit rules
- Multiplying speed by time gives the length traveled. Has to have matching units, for example meters/second and seconds.
- Dividing length by time gives speed. Also needs matching units.
- These are not documehted in the help, because there is no section to fit it and multiplying length to area isn't documented either.

Basically everything has been tested, but no new unit tests have been written, because code is kinda just reused. I will likely make more unit rules for fuel consumption later. 

I know a lot about units, so maybe more will come, but I don't want to have too many obscure or joke units. Maybe light related units like candela could work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Speed × time now yields distances; length ÷ time yields speeds.
  * Added energy units: Gigajoule and TNT-equivalent variants (tTNT, ktTNT, MtTNT).
  * Added "dozen"/"dozens" multiplier (factor 12).

* **Documentation**
  * Reference updated: expanded energy unit table and revised numeral multiplier table (adds "dozen").

* **Tests**
  * Added/expanded tests for speed–time/length derivations and the new energy unit conversions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->