### PR TITLE
Add various auto-open on launch modes and fix misc bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.0] - 2026-04-09
+### Added
+- Added flexible auto-open on launch modes: Choose between Home, Scratchpad, Daily Journal, or a Specific file (Issue #108).
+
+### Fixed
+- Fixed Rational mode resetting when splitting, merging, or deleting lines, and when using undo/redo (Issue #107).
+
 ## [3.4.2] - 2026-04-04
 ### Fixed
 - Made built-in math functions handle unit values more safely, with clearer errors when a function cannot use a given unit.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
     defaultConfig {
         applicationId = "com.vishaltelangre.nerdcalci"
         minSdk = 23
-        versionCode = 342
-        versionName = "3.4.2"
+        versionCode = 350
+        versionName = "3.5.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/androidTest/java/com/vishaltelangre/nerdcalci/data/DatabaseTest.kt
+++ b/app/src/androidTest/java/com/vishaltelangre/nerdcalci/data/DatabaseTest.kt
@@ -652,4 +652,48 @@ class DatabaseTest {
         val file = dao.getFileById(fileId)
         assertTrue(file!!.lastModified >= beforeTouch)
     }
+
+    // ==================== createJournalFileIfAbsent ====================
+
+    @Test
+    fun createJournalFileIfAbsent_newName_insertsFileAndOneLine() = runBlocking {
+        val name = "2024-01-01"
+        val createdAt = 1000L
+
+        val fileId = dao.createJournalFileIfAbsent(name, createdAt)
+
+        // A valid id should be returned
+        assertTrue(fileId > 0)
+
+        // Exactly one FileEntity with that name should exist
+        val file = dao.getFileByName(name)
+        assertNotNull(file)
+        assertEquals(fileId, file!!.id)
+        assertEquals(name, file.name)
+
+        // Exactly one LineEntity should exist for this file, with empty expression and result
+        val lines = dao.getLinesForFileSync(fileId)
+        assertEquals(1, lines.size)
+        assertEquals(fileId, lines[0].fileId)
+        assertEquals("", lines[0].expression)
+        assertEquals("", lines[0].result)
+    }
+
+    @Test
+    fun createJournalFileIfAbsent_existingName_returnsSameIdWithoutDuplicateLine() = runBlocking {
+        val name = "2024-01-02"
+        val createdAt = 2000L
+
+        // First call: creates the file and one empty line
+        val firstId = dao.createJournalFileIfAbsent(name, createdAt)
+        assertTrue(firstId > 0)
+
+        // Second call with the same name: must return the same id
+        val secondId = dao.createJournalFileIfAbsent(name, createdAt)
+        assertEquals(firstId, secondId)
+
+        // No additional LineEntity should have been created
+        val lines = dao.getLinesForFileSync(firstId)
+        assertEquals(1, lines.size)
+    }
 }

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/Constants.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/Constants.kt
@@ -52,5 +52,7 @@ object Constants {
 
     // Temporary scratchpad settings
     const val PREF_AUTO_OPEN_SCRATCHPAD = "auto_open_scratchpad"
+    const val PREF_LAUNCH_MODE = "launch_mode"
+    const val PREF_LAUNCH_FILE_ID = "launch_file_id"
     const val SCRATCHPAD_DISPLAY_NAME = "Scratchpad"
 }

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/LaunchMode.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/LaunchMode.kt
@@ -1,0 +1,21 @@
+package com.vishaltelangre.nerdcalci.core
+
+/**
+ * Launch modes for the application.
+ *
+ * [NOT_SET] - No file auto-opened, shows home screen.
+ * [SCRATCHPAD] - Auto-opens the temporary scratchpad.
+ * [JOURNAL] - Auto-opens today's date-based file (YYYY-MM-DD).
+ * [SPECIFIC_FILE] - Auto-opens a specific file chosen by the user.
+ */
+enum class LaunchMode(val prefValue: String) {
+    NOT_SET("not_set"),
+    SCRATCHPAD("scratchpad"),
+    JOURNAL("journal"),
+    SPECIFIC_FILE("specific_file");
+
+    companion object {
+        fun fromPrefValue(value: String?): LaunchMode =
+            entries.find { it.prefValue == value } ?: NOT_SET
+    }
+}

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/data/local/CalculatorDao.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/data/local/CalculatorDao.kt
@@ -189,6 +189,18 @@ abstract class CalculatorDao {
     }
 
     @Transaction
+    open suspend fun createJournalFileIfAbsent(name: String, createdAt: Long): Long {
+        val existingFile = getFileByName(name)
+        if (existingFile != null) {
+            return existingFile.id
+        }
+        val fileId = insertFile(FileEntity(name = name, lastModified = createdAt, createdAt = createdAt))
+        // Insert a default empty line
+        internalInsertLine(LineEntity(fileId = fileId, sortOrder = 0, expression = "", result = ""))
+        return fileId
+    }
+
+    @Transaction
     open suspend fun createTemporaryFileWithInitialLine(createdAt: Long = System.currentTimeMillis()): Long {
         val uniqueName = "NerdCalci-Scratchpad-${createdAt}"
         val fileId = insertFile(

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/MainActivity.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/MainActivity.kt
@@ -56,9 +56,11 @@ import com.vishaltelangre.nerdcalci.data.backup.BackupLocationMode
 import com.vishaltelangre.nerdcalci.data.backup.BackupManager
 import com.vishaltelangre.nerdcalci.data.local.AppDatabase
 import com.vishaltelangre.nerdcalci.data.local.DatabaseMigrations
-import com.vishaltelangre.nerdcalci.di.CalculatorViewModelFactory
 import com.vishaltelangre.nerdcalci.ui.calculator.CalculatorScreen
+import com.vishaltelangre.nerdcalci.ui.calculator.HomeUiEvent
 import com.vishaltelangre.nerdcalci.ui.calculator.CalculatorViewModel
+import com.vishaltelangre.nerdcalci.di.CalculatorViewModelFactory
+import com.vishaltelangre.nerdcalci.core.LaunchMode
 import com.vishaltelangre.nerdcalci.ui.components.formatBackupLocationText
 import com.vishaltelangre.nerdcalci.ui.components.RestoreBackupListDialog
 import com.vishaltelangre.nerdcalci.ui.components.RestoreSourceDialog
@@ -148,6 +150,11 @@ fun CalculatorNavHost(viewModel: CalculatorViewModel, navController: NavHostCont
     val syncEnabled by viewModel.syncEnabled.collectAsState()
     val syncFolderUri by viewModel.syncFolderUri.collectAsState()
     val lastSyncAt by viewModel.lastSyncAt.collectAsState()
+    val launchMode by viewModel.launchMode.collectAsState()
+    val launchFileId by viewModel.launchFileId.collectAsState()
+    val autoOpenFileId by viewModel.autoOpenFileId.collectAsState()
+    val isAutoOpenReady by viewModel.isAutoOpenReady.collectAsState()
+    val allFiles by viewModel.allFiles.collectAsState(initial = emptyList())
     val customBackupFolderSummary = remember(customBackupFolderUri) {
         val uriString = customBackupFolderUri
         if (uriString != null) {
@@ -239,63 +246,47 @@ fun CalculatorNavHost(viewModel: CalculatorViewModel, navController: NavHostCont
     val slideOutToLeft = slideOutHorizontally(animationSpec = tween(300), targetOffsetX = { fullWidth: Int -> -fullWidth / 3 })
     val slideInFromLeft = slideInHorizontally(animationSpec = tween(300), initialOffsetX = { fullWidth: Int -> -fullWidth / 3 })
     val slideOutToRight = slideOutHorizontally(animationSpec = tween(300), targetOffsetX = { fullWidth: Int -> fullWidth })
-    val launchAutoOpenScratchpad = rememberSaveable { mutableStateOf(viewModel.autoOpenScratchpad.value) }
+    
+    val initialStartDestination = if (launchMode != LaunchMode.NOT_SET) "startup" else "home"
 
     NavHost(
         navController = navController,
-        startDestination = if (launchAutoOpenScratchpad.value) "startup" else "home"
+        startDestination = initialStartDestination
     ) {
         composable("startup") {
-            val scratchpadFileId by viewModel.scratchpadFileId.collectAsState()
-            val isScratchpadReady by viewModel.isScratchpadReady.collectAsState()
             var timedOut by remember { mutableStateOf(false) }
 
             LaunchedEffect(Unit) {
                 delay(5_000L)
-                if (!isScratchpadReady || scratchpadFileId == null) {
+                if (!isAutoOpenReady) {
                     timedOut = true
                 }
             }
 
-            LaunchedEffect(timedOut) {
-                if (timedOut) {
+            LaunchedEffect(isAutoOpenReady, autoOpenFileId, timedOut) {
+                if (timedOut || (isAutoOpenReady && autoOpenFileId == null)) {
                     navController.navigate("home") {
                         popUpTo("startup") { inclusive = true }
                         launchSingleTop = true
                     }
+                } else if (isAutoOpenReady && autoOpenFileId != null) {
+                    suppressHomeAutoOpenOnce = true
+                    navController.navigate("home") {
+                        popUpTo("startup") { inclusive = true }
+                        launchSingleTop = true
+                    }
+                    navController.navigate("editor/$autoOpenFileId")
                 }
             }
 
-            if (isScratchpadReady && scratchpadFileId != null) {
-                CalculatorScreen(
-                    fileId = scratchpadFileId!!,
-                    viewModel = viewModel,
-                    regionCode = regionCode,
-                    onBack = {
-                        suppressHomeAutoOpenOnce = true
-                        navController.navigate("home") {
-                            popUpTo("startup") { inclusive = true }
-                            launchSingleTop = true
-                        }
-                    },
-                    onHelp = { navController.navigate("help") },
-                    onNavigateToFile = { newFileId ->
-                        navController.navigate("editor/$newFileId") {
-                            popUpTo("startup") { inclusive = true }
-                            launchSingleTop = true
-                        }
-                    }
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(32.dp),
+                    color = MaterialTheme.colorScheme.primary
                 )
-            } else {
-                Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center
-                ) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(32.dp),
-                        color = MaterialTheme.colorScheme.primary
-                    )
-                }
             }
         }
 
@@ -312,7 +303,9 @@ fun CalculatorNavHost(viewModel: CalculatorViewModel, navController: NavHostCont
                     showHomeRestoreActionDialog = true
                 },
                 onSearchClick = { navController.navigate("search") },
-                launchAutoOpenScratchpad = launchAutoOpenScratchpad.value,
+                launchMode = launchMode,
+                autoOpenFileId = autoOpenFileId,
+                isAutoOpenReady = isAutoOpenReady,
                 suppressAutoOpenScratchpad = suppressHomeAutoOpenOnce
             )
         }
@@ -359,7 +352,6 @@ fun CalculatorNavHost(viewModel: CalculatorViewModel, navController: NavHostCont
             val precision by viewModel.precision.collectAsState()
             val rationalMode by viewModel.rationalMode.collectAsState()
             val groupingSeparatorEnabled by viewModel.groupingSeparatorEnabled.collectAsState()
-            val autoOpenScratchpad by viewModel.autoOpenScratchpad.collectAsState()
 
             SettingsScreen(
                 currentTheme = currentTheme,
@@ -414,8 +406,17 @@ fun CalculatorNavHost(viewModel: CalculatorViewModel, navController: NavHostCont
                 onRationalModeChange = { viewModel.setRationalMode(it) },
                 groupingSeparatorEnabled = groupingSeparatorEnabled,
                 onGroupingSeparatorEnabledChange = { viewModel.setGroupingSeparatorEnabled(it) },
-                autoOpenScratchpad = autoOpenScratchpad,
-                onAutoOpenScratchpadChange = { viewModel.setAutoOpenScratchpad(it) },
+                launchMode = launchMode,
+                launchFileId = launchFileId,
+                allFiles = allFiles,
+                onLaunchModeChange = { viewModel.setLaunchMode(it) },
+                onLaunchFileIdChange = { viewModel.setLaunchFileId(it) },
+                onAutoValidateLaunchFile = {
+                    viewModel.validateSpecificFileSetting()
+                },
+                onValidateLaunchFile = { fileId, callback ->
+                    viewModel.validateLaunchFile(fileId, callback)
+                },
                 onHelp = { navController.navigate("help") },
                 onChangelog = { navController.navigate("changelog") },
                 onBack = { navController.popBackStack() }

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorScreen.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorScreen.kt
@@ -660,7 +660,7 @@ fun CalculatorScreen(
                     },
                     actions = {
                         IconButton(
-                            onClick = { viewModel.undo(fileId) },
+                            onClick = { viewModel.undo(fileId, effectiveRationalMode) },
                             enabled = canUndo
                         ) {
                             Icon(
@@ -671,7 +671,7 @@ fun CalculatorScreen(
                         }
 
                         IconButton(
-                            onClick = { viewModel.redo(fileId) },
+                            onClick = { viewModel.redo(fileId, effectiveRationalMode) },
                             enabled = canRedo
                         ) {
                             Icon(
@@ -1090,7 +1090,7 @@ fun CalculatorScreen(
                         },
                         onEnter = { expression, splitIndex ->
                             coroutineScope.launch {
-                                val newId = viewModel.splitLine(line.id, splitIndex, expression)
+                                val newId = viewModel.splitLine(line.id, splitIndex, expression, effectiveRationalMode)
                                 focusLineId = newId
                                 // New lines created via Enter (splitting) have a leading space;
                                 // we want to focus at the very start of the moved text (pos 0).
@@ -1106,7 +1106,7 @@ fun CalculatorScreen(
                                     focusLineId = prevLine.id
                                     focusCursorPosition = prevLine.expression.length
                                 }
-                                viewModel.deleteLine(line)
+                                viewModel.deleteLine(line, effectiveRationalMode)
                             }
                         },
                         onMergeWithPrevious = {
@@ -1117,7 +1117,7 @@ fun CalculatorScreen(
                                 focusCursorPosition = prevLine.expression.length
 
                                 coroutineScope.launch {
-                                    viewModel.mergeLines(prevLine.id, currentLine.id)
+                                    viewModel.mergeLines(prevLine.id, currentLine.id, effectiveRationalMode)
                                 }
                             }
                         },

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorViewModel.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorViewModel.kt
@@ -506,7 +506,7 @@ class CalculatorViewModel(
         updateUndoRedoState(fileId)
     }
 
-    fun undo(fileId: Long) {
+    fun undo(fileId: Long, rationalMode: Boolean? = null) {
         viewModelScope.launch(Dispatchers.IO) {
             calculationMutex.withLock {
                 val undoStack = undoStacks[fileId] ?: return@withLock
@@ -520,14 +520,14 @@ class CalculatorViewModel(
 
                 // Restore previous state
                 val previousSnapshot = undoStack.removeAt(undoStack.size - 1)
-                restoreSnapshot(fileId, previousSnapshot)
+                restoreSnapshot(fileId, previousSnapshot, rationalMode)
 
                 updateUndoRedoState(fileId)
             }
         }
     }
 
-    fun redo(fileId: Long) {
+    fun redo(fileId: Long, rationalMode: Boolean? = null) {
         viewModelScope.launch(Dispatchers.IO) {
             calculationMutex.withLock {
                 val redoStack = redoStacks[fileId] ?: return@withLock
@@ -541,19 +541,19 @@ class CalculatorViewModel(
 
                 // Restore redo state
                 val redoSnapshot = redoStack.removeAt(redoStack.size - 1)
-                restoreSnapshot(fileId, redoSnapshot)
+                restoreSnapshot(fileId, redoSnapshot, rationalMode)
 
                 updateUndoRedoState(fileId)
             }
         }
     }
 
-    private suspend fun restoreSnapshot(fileId: Long, snapshot: FileSnapshot) {
+    private suspend fun restoreSnapshot(fileId: Long, snapshot: FileSnapshot, rationalMode: Boolean? = null) {
         dao.restoreLines(fileId, snapshot.lines)
 
         // Recalculate everything and batch-write results in one transaction
         val allLines = dao.getLinesForFileSync(fileId)
-        val effectiveRationalMode = _rationalMode.value
+        val effectiveRationalMode = rationalMode ?: _rationalMode.value
         val calculatedLines = MathEngine.calculate(allLines, createFileContextLoader(fileId, effectiveRationalMode), rationalMode = effectiveRationalMode)
         val versionedLines = calculatedLines.map { it.copy(version = it.version + 1) }
         dao.updateLines(fileId, versionedLines)

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorViewModel.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorViewModel.kt
@@ -388,7 +388,13 @@ class CalculatorViewModel(
 
     fun setLaunchMode(mode: LaunchMode) {
         _launchMode.value = mode
-        prefs?.edit()?.putString(Constants.PREF_LAUNCH_MODE, mode.prefValue)?.apply()
+        val editor = prefs?.edit() ?: return
+        editor.putString(Constants.PREF_LAUNCH_MODE, mode.prefValue)
+        if (mode != LaunchMode.SPECIFIC_FILE) {
+            editor.remove(Constants.PREF_LAUNCH_FILE_ID)
+            _launchFileId.value = null
+        }
+        editor.apply()
     }
 
     fun setLaunchFileId(fileId: Long?) {

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorViewModel.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorViewModel.kt
@@ -429,7 +429,17 @@ class CalculatorViewModel(
                 }
             }
         } else {
-            onResult?.invoke(false)
+            // Handle the case where id == null but LaunchMode is SPECIFIC_FILE
+            if (_launchMode.value == LaunchMode.SPECIFIC_FILE) {
+                viewModelScope.launch(Dispatchers.Main) {
+                    setLaunchMode(LaunchMode.NOT_SET)
+                    prefs?.edit()?.remove(Constants.PREF_LAUNCH_FILE_ID)?.apply()
+                    _launchFileId.value = null
+                    onResult?.invoke(false)
+                }
+            } else {
+                onResult?.invoke(false)
+            }
         }
     }
 

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorViewModel.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorViewModel.kt
@@ -78,7 +78,13 @@ class CalculatorViewModel(
     private val prefs: SharedPreferences? = null
 ) : ViewModel() {
     private val _launchMode = MutableStateFlow(
-        LaunchMode.fromPrefValue(prefs?.getString(Constants.PREF_LAUNCH_MODE, null))
+        LaunchMode.fromPrefValue(prefs?.getString(Constants.PREF_LAUNCH_MODE, null)).let { mode ->
+            if (mode == LaunchMode.NOT_SET && prefs?.getBoolean(Constants.PREF_AUTO_OPEN_SCRATCHPAD, false) == true) {
+                LaunchMode.SCRATCHPAD
+            } else {
+                mode
+            }
+        }
     )
     val launchMode: StateFlow<LaunchMode> = _launchMode
 

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorViewModel.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorViewModel.kt
@@ -155,6 +155,8 @@ class CalculatorViewModel(
 
                 // Resolve which file to auto-open based on current mode
                 resolveAutoOpenFile()
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.e(TAG, "Initialization failed", e)
                 _isAutoOpenReady.value = true // Fallback to home screen

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorViewModel.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorViewModel.kt
@@ -40,8 +40,11 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.withContext
 import com.vishaltelangre.nerdcalci.utils.FileUtils
+import java.util.*
 import java.util.concurrent.atomic.AtomicBoolean
 import com.vishaltelangre.nerdcalci.data.sync.SyncManager
+import com.vishaltelangre.nerdcalci.core.LaunchMode
+import java.text.SimpleDateFormat
 
 sealed class HomeUiEvent {
     data class ShowMessage(val message: String) : HomeUiEvent()
@@ -74,21 +77,32 @@ class CalculatorViewModel(
     private val dao: CalculatorDao,
     private val prefs: SharedPreferences? = null
 ) : ViewModel() {
-    private val _autoOpenScratchpad = MutableStateFlow(
-        prefs?.getBoolean(Constants.PREF_AUTO_OPEN_SCRATCHPAD, false) ?: false
+    private val _launchMode = MutableStateFlow(
+        LaunchMode.fromPrefValue(prefs?.getString(Constants.PREF_LAUNCH_MODE, null))
     )
-    val autoOpenScratchpad: StateFlow<Boolean> = _autoOpenScratchpad
+    val launchMode: StateFlow<LaunchMode> = _launchMode
+
+    private val _launchFileId = MutableStateFlow(
+        prefs?.getLong(Constants.PREF_LAUNCH_FILE_ID, -1L)?.takeIf { it != -1L }
+    )
+    val launchFileId: StateFlow<Long?> = _launchFileId
+
+    private val _autoOpenFileId = MutableStateFlow<Long?>(null)
+    val autoOpenFileId: StateFlow<Long?> = _autoOpenFileId
+
+    private val _isAutoOpenReady = MutableStateFlow(false)
+    val isAutoOpenReady: StateFlow<Boolean> = _isAutoOpenReady
+
+    private val _currentTheme = MutableStateFlow(
+        prefs?.getString(PREF_THEME, DEFAULT_THEME) ?: DEFAULT_THEME
+    )
+    val currentTheme: StateFlow<String> = _currentTheme
 
     private val _scratchpadFileId = MutableStateFlow<Long?>(null)
     val scratchpadFileId: StateFlow<Long?> = _scratchpadFileId
 
     private val _isScratchpadReady = MutableStateFlow(false)
     val isScratchpadReady: StateFlow<Boolean> = _isScratchpadReady
-
-    private val _currentTheme = MutableStateFlow(
-        prefs?.getString(PREF_THEME, DEFAULT_THEME) ?: DEFAULT_THEME
-    )
-    val currentTheme: StateFlow<String> = _currentTheme
 
     private val _precision = MutableStateFlow(
         (prefs?.getInt(Constants.SYNC_ENGINE_PRECISION, Constants.DEFAULT_PRECISION) ?: Constants.DEFAULT_PRECISION)
@@ -127,9 +141,81 @@ class CalculatorViewModel(
     init {
         viewModelScope.launch {
             try {
+                // Perform migration if needed
+                migrateLaunchSettings()
+
+                // Initialize scratchpad (always needed for the "Open Scratchpad" button)
                 ensureScratchpadExists()
+
+                // Resolve which file to auto-open based on current mode
+                resolveAutoOpenFile()
             } catch (e: Exception) {
-                Log.e(TAG, "Failed to initialize scratchpad", e)
+                Log.e(TAG, "Initialization failed", e)
+                _isAutoOpenReady.value = true // Fallback to home screen
+            }
+        }
+    }
+
+    private fun migrateLaunchSettings() {
+        val prefs = prefs ?: return
+        // If the new launch mode isn't set but the old toggle was true, migrate to SCRATCHPAD
+        if (!prefs.contains(Constants.PREF_LAUNCH_MODE) &&
+            prefs.getBoolean(Constants.PREF_AUTO_OPEN_SCRATCHPAD, false)) {
+            setLaunchMode(LaunchMode.SCRATCHPAD)
+        }
+
+        // TODO: Remove PREF_AUTO_OPEN_SCRATCHPAD in a future release
+        if (prefs.contains(Constants.PREF_AUTO_OPEN_SCRATCHPAD)) {
+            prefs.edit().remove(Constants.PREF_AUTO_OPEN_SCRATCHPAD).apply()
+        }
+    }
+
+    fun onValidateLaunchFile(fileId: Long, callback: (Boolean) -> Unit) {
+        viewModelScope.launch {
+            val exists = withContext(Dispatchers.IO) {
+                dao.getFileById(fileId) != null
+            }
+            callback(exists)
+        }
+    }
+
+    private suspend fun resolveAutoOpenFile() {
+        withContext(Dispatchers.IO) {
+            try {
+                val mode = _launchMode.value
+                val fileId = when (mode) {
+                    LaunchMode.NOT_SET -> null
+                    LaunchMode.SCRATCHPAD -> {
+                        // Wait for scratchpad to be ready if it's not yet
+                        var retry = 0
+                        while (_scratchpadFileId.value == null && retry < 10) {
+                            kotlinx.coroutines.delay(100)
+                            retry++
+                        }
+                        _scratchpadFileId.value
+                    }
+                    LaunchMode.JOURNAL -> {
+                        val today = SimpleDateFormat("yyyy-MM-dd", Locale.US).format(Date())
+                        dao.createJournalFileIfAbsent(today, System.currentTimeMillis())
+                    }
+                    LaunchMode.SPECIFIC_FILE -> {
+                        val id = _launchFileId.value
+                        if (id != null && dao.getFileById(id) != null) {
+                            id
+                        } else {
+                            // Reset if file missing
+                            withContext(Dispatchers.Main) {
+                                setLaunchMode(LaunchMode.NOT_SET)
+                                prefs?.edit()?.remove(Constants.PREF_LAUNCH_FILE_ID)?.apply()
+                                _launchFileId.value = null
+                            }
+                            null
+                        }
+                    }
+                }
+                _autoOpenFileId.value = fileId
+            } finally {
+                _isAutoOpenReady.value = true
             }
         }
     }
@@ -292,9 +378,53 @@ class CalculatorViewModel(
     )
     val rationalMode: StateFlow<Boolean> = _rationalMode
 
-    fun setAutoOpenScratchpad(enabled: Boolean) {
-        _autoOpenScratchpad.value = enabled
-        prefs?.edit()?.putBoolean(Constants.PREF_AUTO_OPEN_SCRATCHPAD, enabled)?.apply()
+    fun setLaunchMode(mode: LaunchMode) {
+        _launchMode.value = mode
+        prefs?.edit()?.putString(Constants.PREF_LAUNCH_MODE, mode.prefValue)?.apply()
+    }
+
+    fun setLaunchFileId(fileId: Long?) {
+        _launchFileId.value = fileId
+        val prefs = prefs ?: return
+        if (fileId != null) {
+            prefs.edit().putLong(Constants.PREF_LAUNCH_FILE_ID, fileId).apply()
+            setLaunchMode(LaunchMode.SPECIFIC_FILE)
+        } else {
+            prefs.edit().remove(Constants.PREF_LAUNCH_FILE_ID).apply()
+        }
+    }
+
+    /**
+     * Validates that the specifically set launch file still exists.
+     * Resets to NOT_SET if it has been deleted.
+     */
+    fun validateSpecificFileSetting() {
+        validateLaunchFile()
+    }
+
+    /**
+     * Validates that the specifically set launch file still exists.
+     * Resets to NOT_SET if it has been deleted.
+     */
+    fun validateLaunchFile(fileId: Long? = null, onResult: ((Boolean) -> Unit)? = null) {
+        val id = fileId ?: if (_launchMode.value == LaunchMode.SPECIFIC_FILE) _launchFileId.value else null
+        if (id != null) {
+            viewModelScope.launch(Dispatchers.IO) {
+                val exists = dao.getFileById(id) != null
+                if (!exists && fileId == null) { // Only auto-reset if we're validating the CURRENT setting
+                    withContext(Dispatchers.Main) {
+                        setLaunchMode(LaunchMode.NOT_SET)
+                        prefs?.edit()?.remove(Constants.PREF_LAUNCH_FILE_ID)?.apply()
+                        _launchFileId.value = null
+                    }
+                }
+                withContext(Dispatchers.Main) {
+                    onResult?.invoke(exists)
+                }
+            }
+        } else {
+            onResult?.invoke(false)
+        }
     }
 
     fun setTheme(theme: String) {

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/home/HomeScreen.kt
@@ -60,6 +60,7 @@ import com.vishaltelangre.nerdcalci.core.Constants
 import com.vishaltelangre.nerdcalci.data.local.entities.FileEntity
 import com.vishaltelangre.nerdcalci.ui.calculator.CalculatorViewModel
 import com.vishaltelangre.nerdcalci.ui.calculator.HomeUiEvent
+import com.vishaltelangre.nerdcalci.core.LaunchMode
 import com.vishaltelangre.nerdcalci.ui.components.SectionHeader
 import com.vishaltelangre.nerdcalci.ui.components.addDismissibleFileItems
 import kotlinx.coroutines.CoroutineScope
@@ -92,7 +93,9 @@ fun HomeScreen(
     onChangelogClick: () -> Unit,
     onRestoreClick: () -> Unit,
     onSearchClick: () -> Unit,
-    launchAutoOpenScratchpad: Boolean,
+    launchMode: LaunchMode,
+    autoOpenFileId: Long?,
+    isAutoOpenReady: Boolean,
     suppressAutoOpenScratchpad: Boolean = false
 ) {
     val context = LocalContext.current
@@ -109,12 +112,11 @@ fun HomeScreen(
         }
     }
 
-    val scratchpadFileId by viewModel.scratchpadFileId.collectAsState()
-    val isScratchpadReady by viewModel.isScratchpadReady.collectAsState()
     var hasAutoOpened by rememberSaveable { mutableStateOf(false) }
 
     // Handle UI events like Undo Snackbars and other messages
     val excludedFileIds by viewModel.excludedFileIds.collectAsState(initial = emptySet())
+    val scratchpadFileId by viewModel.scratchpadFileId.collectAsState()
 
     val syncEnabled by viewModel.syncEnabled.collectAsState()
     val isSyncing by viewModel.isSyncing.collectAsState()
@@ -127,16 +129,17 @@ fun HomeScreen(
         }
     }
 
-    LaunchedEffect(launchAutoOpenScratchpad, scratchpadFileId, isScratchpadReady, suppressAutoOpenScratchpad) {
+    // Auto-open logic on launch
+    LaunchedEffect(isAutoOpenReady, launchMode, autoOpenFileId, suppressAutoOpenScratchpad) {
         if (
-            launchAutoOpenScratchpad &&
+            isAutoOpenReady &&
             !suppressAutoOpenScratchpad &&
-            scratchpadFileId != null &&
-            isScratchpadReady &&
+            launchMode != LaunchMode.NOT_SET &&
+            autoOpenFileId != null &&
             !hasAutoOpened
         ) {
             hasAutoOpened = true
-            onFileClick(scratchpadFileId!!)
+            onFileClick(autoOpenFileId)
         }
     }
 
@@ -441,8 +444,8 @@ private fun HomeFileList(
                     }
                 },
                 onTogglePin = { id -> viewModel.togglePinFile(id) },
-                onUndo = { viewModel.undoHideFile(it) },
-                onDismiss = { viewModel.hideFile(it) },
+                onUndo = { id: Long -> viewModel.undoHideFile(id) },
+                onDismiss = { id: Long -> viewModel.hideFile(id) },
                 viewModel = viewModel
             )
         }
@@ -473,8 +476,8 @@ private fun HomeFileList(
                     }
                 },
                 onTogglePin = { id -> viewModel.togglePinFile(id) },
-                onUndo = { viewModel.undoHideFile(it) },
-                onDismiss = { viewModel.hideFile(it) },
+                onUndo = { id: Long -> viewModel.undoHideFile(id) },
+                onDismiss = { id: Long -> viewModel.hideFile(id) },
                 viewModel = viewModel
             )
         }

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/settings/SettingsScreen.kt
@@ -37,6 +37,10 @@ import androidx.compose.material.icons.filled.Coffee
 import androidx.compose.material.icons.filled.DarkMode
 import androidx.compose.material.icons.filled.Description
 import androidx.compose.material.icons.filled.FormatListNumbered
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import com.vishaltelangre.nerdcalci.ui.components.RestoreSourceDialog
+import com.vishaltelangre.nerdcalci.ui.components.RestoreBackupListDialog
 import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.LightMode
@@ -90,11 +94,11 @@ import com.vishaltelangre.nerdcalci.data.backup.BackupFileInfo
 import com.vishaltelangre.nerdcalci.data.backup.BackupFrequency
 import com.vishaltelangre.nerdcalci.data.backup.BackupLocationMode
 import com.vishaltelangre.nerdcalci.ui.theme.FiraCodeFamily
-import com.vishaltelangre.nerdcalci.utils.FileUtils
-import com.vishaltelangre.nerdcalci.ui.components.RestoreBackupListDialog
-import com.vishaltelangre.nerdcalci.ui.components.RestoreSourceDialog
+import com.vishaltelangre.nerdcalci.core.LaunchMode
+import com.vishaltelangre.nerdcalci.data.local.entities.FileEntity
 import com.vishaltelangre.nerdcalci.ui.components.RegionSelectorDialog
 import com.vishaltelangre.nerdcalci.ui.components.formatBackupLocationText
+import com.vishaltelangre.nerdcalci.utils.FileUtils
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -136,8 +140,13 @@ fun SettingsScreen(
     onRationalModeChange: (Boolean) -> Unit,
     groupingSeparatorEnabled: Boolean,
     onGroupingSeparatorEnabledChange: (Boolean) -> Unit,
-    autoOpenScratchpad: Boolean,
-    onAutoOpenScratchpadChange: (Boolean) -> Unit,
+    launchMode: LaunchMode,
+    onLaunchModeChange: (LaunchMode) -> Unit,
+    launchFileId: Long?,
+    onLaunchFileIdChange: (Long?) -> Unit,
+    allFiles: List<FileEntity>,
+    onAutoValidateLaunchFile: () -> Unit,
+    onValidateLaunchFile: (Long, (Boolean) -> Unit) -> Unit,
     onHelp: () -> Unit,
     onChangelog: () -> Unit,
     onBack: () -> Unit
@@ -149,6 +158,8 @@ fun SettingsScreen(
     var showLocationDialog by remember { mutableStateOf(false) }
     var showFrequencyDialog by remember { mutableStateOf(false) }
     var showRegionDialog by remember { mutableStateOf(false) }
+    var showLaunchModeDialog by remember { mutableStateOf(false) }
+    var showSelectFileDialog by remember { mutableStateOf(false) }
 
     var sliderValue by remember(precision) { mutableStateOf(precision.toFloat()) }
 
@@ -180,6 +191,13 @@ fun SettingsScreen(
     fun openUrl(url: String) {
         val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
         context.startActivity(intent)
+    }
+
+    // Validate the specific file if set
+    androidx.compose.runtime.LaunchedEffect(Unit) {
+        if (launchMode == LaunchMode.SPECIFIC_FILE) {
+            onAutoValidateLaunchFile()
+        }
     }
 
     Scaffold(
@@ -362,12 +380,37 @@ fun SettingsScreen(
                 modifier = Modifier.padding(horizontal = 56.dp).padding(bottom = 8.dp)
             )
 
-            SettingsToggleItem(
-                icon = Icons.Default.FlashOn,
-                title = "Auto-open temporary scratchpad on launch",
-                subtitle = "Opens the temporary scratchpad automatically when you start the app. Changes in this file are never saved.",
-                checked = autoOpenScratchpad,
-                onCheckedChange = onAutoOpenScratchpadChange
+            SettingsDropdownItem(
+                icon = when (launchMode) {
+                    LaunchMode.NOT_SET -> Icons.Default.Restore
+                    LaunchMode.SCRATCHPAD -> Icons.Default.FlashOn
+                    LaunchMode.JOURNAL -> Icons.Default.Schedule
+                    LaunchMode.SPECIFIC_FILE -> Icons.Default.Description
+                },
+                title = "Auto-open file on launch",
+                value = when (launchMode) {
+                    LaunchMode.NOT_SET -> "Not set"
+                    LaunchMode.SCRATCHPAD -> "Temporary scratchpad"
+                    LaunchMode.JOURNAL -> "Daily journal (YYYY-MM-DD)"
+                    LaunchMode.SPECIFIC_FILE -> {
+                        val file = allFiles.find { it.id == launchFileId }
+                        file?.name ?: "Choose file..."
+                    }
+                },
+                onClick = {
+                    if (launchMode == LaunchMode.SPECIFIC_FILE && launchFileId != null) {
+                        onValidateLaunchFile(launchFileId) { exists ->
+                            if (!exists) {
+                                // If stored file is gone, show selector immediately
+                                showSelectFileDialog = true
+                            } else {
+                                showLaunchModeDialog = true
+                            }
+                        }
+                    } else {
+                        showLaunchModeDialog = true
+                    }
+                }
             )
 
             Spacer(modifier = Modifier.height(8.dp))
@@ -770,6 +813,137 @@ fun SettingsScreen(
             showRegionDialog = false
         },
         onDismiss = { showRegionDialog = false }
+    )
+
+    if (showLaunchModeDialog) {
+        LaunchModeDialog(
+            currentMode = launchMode,
+            onSelect = { mode ->
+                showLaunchModeDialog = false
+                if (mode == LaunchMode.SPECIFIC_FILE) {
+                    showSelectFileDialog = true
+                } else {
+                    onLaunchModeChange(mode)
+                }
+            },
+            onDismiss = { showLaunchModeDialog = false }
+        )
+    }
+
+    if (showSelectFileDialog) {
+        SelectAutoOpenFileDialog(
+            files = allFiles,
+            currentFileId = launchFileId,
+            onSelect = { fileId ->
+                showSelectFileDialog = false
+                onLaunchModeChange(LaunchMode.SPECIFIC_FILE)
+                onLaunchFileIdChange(fileId)
+            },
+            onDismiss = { showSelectFileDialog = false }
+        )
+    }
+}
+
+@Composable
+private fun LaunchModeDialog(
+    currentMode: LaunchMode,
+    onSelect: (LaunchMode) -> Unit,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Auto-open on launch") },
+        text = {
+            Column(modifier = Modifier.fillMaxWidth()) {
+                val options = listOf(
+                    LaunchMode.NOT_SET to "Not set",
+                    LaunchMode.SCRATCHPAD to "Temporary scratchpad",
+                    LaunchMode.JOURNAL to "Daily journal (YYYY-MM-DD)",
+                    LaunchMode.SPECIFIC_FILE to "Specific file"
+                )
+
+                options.forEach { (mode, label) ->
+                    TextButton(
+                        onClick = { onSelect(mode) },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(
+                                text = label,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = if (currentMode == mode) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface
+                            )
+                            Spacer(modifier = Modifier.weight(1f))
+                            if (currentMode == mode) {
+                                Icon(
+                                    imageVector = Icons.Default.Check,
+                                    contentDescription = "Selected",
+                                    tint = MaterialTheme.colorScheme.primary
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        }
+    )
+}
+
+@Composable
+private fun SelectAutoOpenFileDialog(
+    files: List<FileEntity>,
+    currentFileId: Long?,
+    onSelect: (Long) -> Unit,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Select file") },
+        text = {
+            if (files.isEmpty()) {
+                Text("No files available to select.")
+            } else {
+                val sortedFiles = remember(files) { files.sortedBy { it.name } }
+                LazyColumn(
+                    modifier = Modifier.fillMaxWidth().height(300.dp)
+                ) {
+                    items(sortedFiles) { file ->
+                        TextButton(
+                            onClick = { onSelect(file.id) },
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Text(
+                                    text = file.name,
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = if (currentFileId == file.id) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface
+                                )
+                                Spacer(modifier = Modifier.weight(1f))
+                                if (currentFileId == file.id) {
+                                    Icon(
+                                        imageVector = Icons.Default.Check,
+                                        contentDescription = "Selected",
+                                        tint = MaterialTheme.colorScheme.primary
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        }
     )
 }
 

--- a/fastlane/metadata/android/en-US/changelogs/350.txt
+++ b/fastlane/metadata/android/en-US/changelogs/350.txt
@@ -1,2 +1,2 @@
-- Fixed Rational mode resetting when splitting, merging, or deleting lines, and when using undo/redo.
-- Added flexible auto-open on launch modes: Choose between Home, Scratchpad, Daily Journal, or a Specific file.
+- Fixed Rational mode resetting when splitting, merging, or deleting lines, and when using undo/redo (Issue #107).
+- Added flexible auto-open on launch modes: Choose between Home, Scratchpad, Daily Journal, or a Specific file (Issue #108).

--- a/fastlane/metadata/android/en-US/changelogs/350.txt
+++ b/fastlane/metadata/android/en-US/changelogs/350.txt
@@ -1,2 +1,2 @@
-- Fixed Rational mode resetting when splitting, merging, or deleting lines, and when using undo/redo (Issue #107).
-- Added flexible auto-open on launch modes: Choose between Home, Scratchpad, Daily Journal, or a Specific file (Issue #108).
+- Fixed Rational mode resetting when splitting, merging, or deleting lines, and when using undo/redo.
+- Added flexible auto-open on launch modes: Choose between Home, Scratchpad, Daily Journal, or a Specific file.

--- a/fastlane/metadata/android/en-US/changelogs/350.txt
+++ b/fastlane/metadata/android/en-US/changelogs/350.txt
@@ -1,0 +1,2 @@
+- Fixed Rational mode resetting when splitting, merging, or deleting lines, and when using undo/redo (Issue #107).
+- Added flexible auto-open on launch modes: Choose between Home, Scratchpad, Daily Journal, or a Specific file (Issue #108).


### PR DESCRIPTION
- Fixes #107.
- Fixes #108.
- Fixes #101.

Released in version [v3.5.0](https://github.com/vishaltelangre/NerdCalci/releases/tag/v3.5.0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable auto-open on launch: choose Home, Scratchpad, Daily Journal, or a specific file.

* **Bug Fixes**
  * Rational mode no longer resets when splitting, merging, deleting lines, or during undo/redo.

* **Chores**
  * Android app updated to version 3.5.0.

* **Documentation**
  * Added release notes for 3.5.0.

* **Tests**
  * Added DAO tests ensuring journal file creation is idempotent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->