### PR TITLE
Too precise number truncation, ability to toggle scratchpad shortcut visibility and misc bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed an issue where changing "Auto-open a file on launch" settings caused unintended navigation.
+- Fixed an issue where the calculator's last sync time was not persisted across application restarts.
 
 ## [3.5.0] - 2026-04-09
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.6.0] - 2026-04-09
+### Added
+- Added a global setting to show an ellipsis for truncated numbers that exceed the configured result precision (Issue #106).
+- Added a configurable setting to show or hide the temporary scratchpad shortcut on the home screen via a new bolt icon (Issue #109).
+
+### Fixed
+- Fixed an issue where changing "Auto-open a file on launch" settings caused unintended navigation.
+
 ## [3.5.0] - 2026-04-09
 ### Added
 - Added flexible auto-open on launch modes: Choose between Home, Scratchpad, Daily Journal, or a Specific file (Issue #108).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
     defaultConfig {
         applicationId = "com.vishaltelangre.nerdcalci"
         minSdk = 23
-        versionCode = 350
-        versionName = "3.5.0"
+        versionCode = 360
+        versionName = "3.6.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/Constants.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/Constants.kt
@@ -51,7 +51,8 @@ object Constants {
     const val DEFAULT_RATIONAL_MODE = false
 
     // Temporary scratchpad settings
-    const val PREF_AUTO_OPEN_SCRATCHPAD = "auto_open_scratchpad"
+    const val PREF_AUTO_OPEN_SCRATCHPAD = "auto_open_scratchpad" // @deprecated
+    const val PREF_SHOW_SCRATCHPAD = "show_scratchpad"
     const val PREF_LAUNCH_MODE = "launch_mode"
     const val PREF_LAUNCH_FILE_ID = "launch_file_id"
     const val PREF_SHOW_PRECISION_ELLIPSIS = "show_precision_ellipsis"

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/Constants.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/Constants.kt
@@ -54,5 +54,6 @@ object Constants {
     const val PREF_AUTO_OPEN_SCRATCHPAD = "auto_open_scratchpad"
     const val PREF_LAUNCH_MODE = "launch_mode"
     const val PREF_LAUNCH_FILE_ID = "launch_file_id"
+    const val PREF_SHOW_PRECISION_ELLIPSIS = "show_precision_ellipsis"
     const val SCRATCHPAD_DISPLAY_NAME = "Scratchpad"
 }

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/MathEngine.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/MathEngine.kt
@@ -511,13 +511,19 @@ object MathEngine {
             }
             formatNumeralSystem(value.toLong(), radix) to false
         } else {
-            val rounded = value.setScale(safePrecision, java.math.RoundingMode.HALF_UP)
-            val truncated = value.compareTo(rounded) != 0
+            val isScientific = numStr.contains('E', ignoreCase = true) ||
+                    value.abs() >= BigDecimal("1000000000000000") || // 10^15
+                    (value.abs() < BigDecimal("0.001") && value.abs() > BigDecimal.ZERO)
+
+            val truncated = if (isScientific) {
+                isScientificTruncated(value, safePrecision)
+            } else {
+                value.compareTo(value.setScale(safePrecision, java.math.RoundingMode.HALF_UP)) != 0
+            }
+
             val roundingMode = if (truncated && showEllipsis) java.math.RoundingMode.DOWN else java.math.RoundingMode.HALF_UP
 
-            val formatted = if (numStr.contains('E', ignoreCase = true) ||
-                value.abs() >= BigDecimal("1000000000000000") || // 10^15, reasonable threshold before Long range end
-                (value.abs() < BigDecimal("0.001") && value.abs() > BigDecimal.ZERO)) {
+            val formatted = if (isScientific) {
                 formatScientific(value, safePrecision, locale, roundingMode)
             } else {
                 val useIndianStyle = regionCode == "IN" ||
@@ -636,6 +642,14 @@ object MathEngine {
         return (first3 + separator + groupedRest).reversed()
     }
 
+
+    private fun isScientificTruncated(value: BigDecimal, precision: Int): Boolean {
+        if (value.compareTo(BigDecimal.ZERO) == 0) return false
+        val exponent = value.precision() - value.scale() - 1
+        val mantissa = value.movePointLeft(exponent)
+        val roundedMantissa = mantissa.setScale(precision.coerceAtLeast(0), java.math.RoundingMode.HALF_UP)
+        return mantissa.compareTo(roundedMantissa) != 0
+    }
 
     private fun formatScientific(
         value: BigDecimal,

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/MathEngine.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/MathEngine.kt
@@ -480,7 +480,8 @@ object MathEngine {
         precision: Int,
         systemLocale: Locale = Locale.getDefault(),
         regionCode: String = RegionUtils.SYSTEM_DEFAULT,
-        groupingSeparatorEnabled: Boolean = true
+        groupingSeparatorEnabled: Boolean = true,
+        showEllipsis: Boolean = false
     ): String {
         if (rawResult.isBlank() || rawResult == "Err") return rawResult
 
@@ -500,7 +501,7 @@ object MathEngine {
         val trimmedUnit = unitStr.trim().lowercase()
         val isNumeralSystem = UnitConverter.isNumeralSystemSymbol(trimmedUnit)
 
-        val formattedResult = if (isNumeralSystem) {
+        val (formattedResult, isTruncated) = if (isNumeralSystem) {
             if (value.remainder(BigDecimal.ONE).compareTo(BigDecimal.ZERO) != 0) return "Err"
             val radix = when (trimmedUnit) {
                 "bin" -> 2
@@ -508,20 +509,28 @@ object MathEngine {
                 "oct" -> 8
                 else -> 10
             }
-            formatNumeralSystem(value.toLong(), radix)
-        } else if (numStr.contains('E', ignoreCase = true) ||
-                   value.abs() >= BigDecimal("1000000000000000") || // 10^15, reasonable threshold before Long range end
-                   (value.abs() < BigDecimal("0.001") && value.abs() > BigDecimal.ZERO)) {
-            formatScientific(value, safePrecision, locale)
+            formatNumeralSystem(value.toLong(), radix) to false
         } else {
-            val useIndianStyle = regionCode == "IN" ||
-                    (regionCode == RegionUtils.SYSTEM_DEFAULT && locale.country == "IN")
-            val isWholeNumber = value.remainder(BigDecimal.ONE).compareTo(BigDecimal.ZERO) == 0
-            val forcePrecision = !isWholeNumber // Only force trailing zeros for actual decimals
-            formatLocalized(value, safePrecision, locale, alwaysDecimal = false, forcePrecision = forcePrecision, useIndianStyle = useIndianStyle, groupingSeparatorEnabled = groupingSeparatorEnabled)
+            val rounded = value.setScale(safePrecision, java.math.RoundingMode.HALF_UP)
+            val truncated = value.compareTo(rounded) != 0
+            val roundingMode = if (truncated && showEllipsis) java.math.RoundingMode.DOWN else java.math.RoundingMode.HALF_UP
+
+            val formatted = if (numStr.contains('E', ignoreCase = true) ||
+                value.abs() >= BigDecimal("1000000000000000") || // 10^15, reasonable threshold before Long range end
+                (value.abs() < BigDecimal("0.001") && value.abs() > BigDecimal.ZERO)) {
+                formatScientific(value, safePrecision, locale, roundingMode)
+            } else {
+                val useIndianStyle = regionCode == "IN" ||
+                        (regionCode == RegionUtils.SYSTEM_DEFAULT && locale.country == "IN")
+                val isWholeNumber = value.remainder(BigDecimal.ONE).compareTo(BigDecimal.ZERO) == 0
+                val forcePrecision = !isWholeNumber // Only force trailing zeros for actual decimals
+                formatLocalized(value, safePrecision, locale, alwaysDecimal = false, forcePrecision = forcePrecision, useIndianStyle = useIndianStyle, groupingSeparatorEnabled = groupingSeparatorEnabled, roundingMode = roundingMode)
+            }
+            formatted to truncated
         }
 
-        return if (isNumeralSystem) formattedResult else formattedResult + unitStr
+        val ellipsis = if (isTruncated && showEllipsis) "…" else ""
+        return if (isNumeralSystem) formattedResult else formattedResult + ellipsis + unitStr
     }
 
     /** Helper to format BigDecimal like Double for integers but with BigDecimal's precision for decimals. */
@@ -569,13 +578,14 @@ object MathEngine {
         alwaysDecimal: Boolean,
         forcePrecision: Boolean = false,
         useIndianStyle: Boolean = false,
-        groupingSeparatorEnabled: Boolean = true
+        groupingSeparatorEnabled: Boolean = true,
+        roundingMode: java.math.RoundingMode = java.math.RoundingMode.HALF_UP
     ): String {
         val symbols = getSafeSymbols(locale, groupingSeparatorEnabled)
+        val roundedValue = value.setScale(precision, roundingMode)
 
         if (useIndianStyle) {
-            val rounded = value.setScale(precision, java.math.RoundingMode.HALF_UP)
-            val s = rounded.toPlainString()
+            val s = roundedValue.toPlainString()
             val parts = s.split('.', limit = 2)
             val integerPart = parts[0]
             val decimalPart = parts.getOrNull(1)
@@ -612,7 +622,7 @@ object MathEngine {
         formatter.maximumFractionDigits = precision
         formatter.minimumFractionDigits = if (forcePrecision) precision else if (alwaysDecimal) 1 else 0
 
-        return formatter.format(value)
+        return formatter.format(roundedValue)
     }
 
     private fun formatIndianStyle(unsigned: String, separator: Char): String {
@@ -627,14 +637,19 @@ object MathEngine {
     }
 
 
-    private fun formatScientific(value: BigDecimal, precision: Int, locale: Locale): String {
+    private fun formatScientific(
+        value: BigDecimal,
+        precision: Int,
+        locale: Locale,
+        roundingMode: java.math.RoundingMode = java.math.RoundingMode.HALF_UP
+    ): String {
         val exponent = value.precision() - value.scale() - 1
         val mantissaScale = precision.coerceAtLeast(0)
-        var mantissa = value.movePointLeft(exponent).setScale(mantissaScale, java.math.RoundingMode.HALF_UP)
+        var mantissa = value.movePointLeft(exponent).setScale(mantissaScale, roundingMode)
         var adjustedExponent = exponent
 
         if (mantissa.abs() >= BigDecimal.TEN) {
-            mantissa = mantissa.movePointLeft(1).setScale(mantissaScale, java.math.RoundingMode.HALF_UP)
+            mantissa = mantissa.movePointLeft(1).setScale(mantissaScale, roundingMode)
             adjustedExponent += 1
         }
 

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/MainActivity.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/MainActivity.kt
@@ -155,6 +155,7 @@ fun CalculatorNavHost(viewModel: CalculatorViewModel, navController: NavHostCont
     val autoOpenFileId by viewModel.autoOpenFileId.collectAsState()
     val isAutoOpenReady by viewModel.isAutoOpenReady.collectAsState()
     val allFiles by viewModel.allFiles.collectAsState(initial = emptyList())
+    val showPrecisionEllipsis by viewModel.showPrecisionEllipsis.collectAsState()
     val customBackupFolderSummary = remember(customBackupFolderUri) {
         val uriString = customBackupFolderUri
         if (uriString != null) {
@@ -323,11 +324,13 @@ fun CalculatorNavHost(viewModel: CalculatorViewModel, navController: NavHostCont
             popEnterTransition = { slideInFromLeft },
             popExitTransition = { slideOutToRight }
         ) { backStackEntry ->
+            val showPrecisionEllipsis by viewModel.showPrecisionEllipsis.collectAsState()
             val fileId = backStackEntry.arguments?.getLong("fileId") ?: 0L
             CalculatorScreen(
                 fileId = fileId,
                 viewModel = viewModel,
                 regionCode = regionCode,
+                showPrecisionEllipsis = showPrecisionEllipsis,
                 onBack = { navController.popBackStack() },
                 onHelp = { navController.navigate("help") },
                 onNavigateToFile = { newFileId ->
@@ -406,6 +409,8 @@ fun CalculatorNavHost(viewModel: CalculatorViewModel, navController: NavHostCont
                 onRationalModeChange = { viewModel.setRationalMode(it) },
                 groupingSeparatorEnabled = groupingSeparatorEnabled,
                 onGroupingSeparatorEnabledChange = { viewModel.setGroupingSeparatorEnabled(it) },
+                showPrecisionEllipsis = showPrecisionEllipsis,
+                onShowPrecisionEllipsisChange = { viewModel.setShowPrecisionEllipsis(it) },
                 launchMode = launchMode,
                 launchFileId = launchFileId,
                 allFiles = allFiles,

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/MainActivity.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/MainActivity.kt
@@ -146,7 +146,7 @@ fun CalculatorNavHost(viewModel: CalculatorViewModel, navController: NavHostCont
     val showNumbersShortcuts by viewModel.showNumbersShortcuts.collectAsState()
     val regionCode by viewModel.regionCode.collectAsState()
     val restoreProgress by viewModel.restoreProgress.collectAsState()
-    
+
     val syncEnabled by viewModel.syncEnabled.collectAsState()
     val syncFolderUri by viewModel.syncFolderUri.collectAsState()
     val lastSyncAt by viewModel.lastSyncAt.collectAsState()
@@ -248,7 +248,7 @@ fun CalculatorNavHost(viewModel: CalculatorViewModel, navController: NavHostCont
     val slideOutToLeft = slideOutHorizontally(animationSpec = tween(300), targetOffsetX = { fullWidth: Int -> -fullWidth / 3 })
     val slideInFromLeft = slideInHorizontally(animationSpec = tween(300), initialOffsetX = { fullWidth: Int -> -fullWidth / 3 })
     val slideOutToRight = slideOutHorizontally(animationSpec = tween(300), targetOffsetX = { fullWidth: Int -> fullWidth })
-    
+
     val initialStartDestination = remember { if (viewModel.launchMode.value != LaunchMode.NOT_SET) "startup" else "home" }
 
     NavHost(
@@ -272,14 +272,14 @@ fun CalculatorNavHost(viewModel: CalculatorViewModel, navController: NavHostCont
                         launchSingleTop = true
                     }
                 } else if (isAutoOpenReady && autoOpenFileId != null) {
-                    suppressHomeAutoOpenOnce = true
-                    navController.navigate("home") {
-                        popUpTo("startup") { inclusive = true }
-                        launchSingleTop = true
+                        suppressHomeAutoOpenOnce = true
+                        navController.navigate("home") {
+                            popUpTo("startup") { inclusive = true }
+                            launchSingleTop = true
+                        }
+                        navController.navigate("editor/$autoOpenFileId")
                     }
-                    navController.navigate("editor/$autoOpenFileId")
                 }
-            }
 
             Box(
                 modifier = Modifier.fillMaxSize(),
@@ -379,7 +379,7 @@ fun CalculatorNavHost(viewModel: CalculatorViewModel, navController: NavHostCont
                         }
                     }
                 },
-                onBackupNowAtDifferentLocation = { 
+                onBackupNowAtDifferentLocation = {
                     val timestamp = SimpleDateFormat("yyyy-MM-dd-HH-mm-ss", Locale.getDefault()).format(Date())
                     val filename = "nerdcalci_backup_$timestamp.zip"
                     exportLauncher.launch(filename)
@@ -387,8 +387,8 @@ fun CalculatorNavHost(viewModel: CalculatorViewModel, navController: NavHostCont
                 lastBackupAt = lastBackupAt,
                 availableBackups = availableBackups,
                 onRestoreBackup = { backup -> viewModel.restoreFromBackup(context, backup) },
-                onRestoreFromDifferentLocation = { 
-                    importLauncher.launch(arrayOf(Constants.EXPORT_MIME_TYPE)) 
+                onRestoreFromDifferentLocation = {
+                    importLauncher.launch(arrayOf(Constants.EXPORT_MIME_TYPE))
                 },
                 precision = precision,
                 onPrecisionChange = { newPrecision -> viewModel.setPrecision(newPrecision) },

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/MainActivity.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/MainActivity.kt
@@ -249,7 +249,7 @@ fun CalculatorNavHost(viewModel: CalculatorViewModel, navController: NavHostCont
     val slideInFromLeft = slideInHorizontally(animationSpec = tween(300), initialOffsetX = { fullWidth: Int -> -fullWidth / 3 })
     val slideOutToRight = slideOutHorizontally(animationSpec = tween(300), targetOffsetX = { fullWidth: Int -> fullWidth })
     
-    val initialStartDestination = if (launchMode != LaunchMode.NOT_SET) "startup" else "home"
+    val initialStartDestination = remember { if (viewModel.launchMode.value != LaunchMode.NOT_SET) "startup" else "home" }
 
     NavHost(
         navController = navController,

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/MainActivity.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/MainActivity.kt
@@ -156,6 +156,7 @@ fun CalculatorNavHost(viewModel: CalculatorViewModel, navController: NavHostCont
     val isAutoOpenReady by viewModel.isAutoOpenReady.collectAsState()
     val allFiles by viewModel.allFiles.collectAsState(initial = emptyList())
     val showPrecisionEllipsis by viewModel.showPrecisionEllipsis.collectAsState()
+    val showScratchpad by viewModel.showScratchpad.collectAsState()
     val customBackupFolderSummary = remember(customBackupFolderUri) {
         val uriString = customBackupFolderUri
         if (uriString != null) {
@@ -307,7 +308,8 @@ fun CalculatorNavHost(viewModel: CalculatorViewModel, navController: NavHostCont
                 launchMode = launchMode,
                 autoOpenFileId = autoOpenFileId,
                 isAutoOpenReady = isAutoOpenReady,
-                suppressAutoOpenScratchpad = suppressHomeAutoOpenOnce
+                suppressAutoOpenScratchpad = suppressHomeAutoOpenOnce,
+                showScratchpad = showScratchpad
             )
         }
 
@@ -416,6 +418,8 @@ fun CalculatorNavHost(viewModel: CalculatorViewModel, navController: NavHostCont
                 allFiles = allFiles,
                 onLaunchModeChange = { viewModel.setLaunchMode(it) },
                 onLaunchFileIdChange = { viewModel.setLaunchFileId(it) },
+                showScratchpad = showScratchpad,
+                onShowScratchpadChange = { viewModel.setShowScratchpad(it) },
                 onAutoValidateLaunchFile = {
                     viewModel.validateSpecificFileSetting()
                 },

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorScreen.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorScreen.kt
@@ -455,6 +455,7 @@ fun CalculatorScreen(
     fileId: Long,
     viewModel: CalculatorViewModel,
     regionCode: String,
+    showPrecisionEllipsis: Boolean,
     onBack: () -> Unit,
     onHelp: () -> Unit,
     onNavigateToFile: (Long) -> Unit = {}
@@ -1050,6 +1051,7 @@ fun CalculatorScreen(
                         numberWidth = numberWidth,
                         availableVariables = availableVariables,
                         fileVariables = fileVariables,
+                        showPrecisionEllipsis = showPrecisionEllipsis,
                         allFiles = files,
                         onGetSuggestionsForFile = viewModel::getSuggestionsForFile,
                         shouldFocus = focusLineId == line.id,
@@ -1216,8 +1218,41 @@ fun CalculatorScreen(
     }
 }
 
-private fun formatResult(text: String, precision: Int, regionCode: String, groupingSeparatorEnabled: Boolean): String {
-    return MathEngine.formatDisplayResult(text, precision, regionCode = regionCode, groupingSeparatorEnabled = groupingSeparatorEnabled)
+private fun formatResult(
+    text: String,
+    precision: Int,
+    regionCode: String,
+    groupingSeparatorEnabled: Boolean,
+    showEllipsis: Boolean = false
+): String {
+    return MathEngine.formatDisplayResult(
+        text,
+        precision,
+        regionCode = regionCode,
+        groupingSeparatorEnabled = groupingSeparatorEnabled,
+        showEllipsis = showEllipsis
+    )
+}
+
+private fun formatAnnotatedResult(
+    text: String,
+    precision: Int,
+    regionCode: String,
+    groupingSeparatorEnabled: Boolean,
+    showPrecisionEllipsis: Boolean,
+    resultColor: Color
+): AnnotatedString {
+    val formatted = formatResult(text, precision, regionCode, groupingSeparatorEnabled, showPrecisionEllipsis)
+    return buildAnnotatedString {
+        if (showPrecisionEllipsis && formatted.endsWith("…")) {
+            append(formatted.dropLast(1))
+            withStyle(SpanStyle(color = resultColor.copy(alpha = 0.5f), fontWeight = FontWeight.Normal)) {
+                append("…")
+            }
+        } else {
+            append(formatted)
+        }
+    }
 }
 
 @Composable
@@ -1264,6 +1299,7 @@ private fun LineRow(
     lineNumber: Int,
     showLineNumbers: Boolean,
     showSuggestions: Boolean,
+    showPrecisionEllipsis: Boolean,
     precision: Int,
     regionCode: String,
     numberWidth: Dp,
@@ -1890,7 +1926,8 @@ private fun LineRow(
                 } else {
                     Modifier.clickable {
                         if (line.result.isNotEmpty()) {
-                            onCopyResult(formatResult(line.result, precision, regionCode, groupingSeparatorEnabled))
+                            // Copying always uses the standard rounded version without ellipsis
+                            onCopyResult(formatResult(line.result, precision, regionCode, groupingSeparatorEnabled, showEllipsis = false))
                             showCopiedTooltip = true
                         }
                     }
@@ -1923,7 +1960,14 @@ private fun LineRow(
                         )
                     }
                     Text(
-                        text = formatResult(line.result, precision, regionCode, groupingSeparatorEnabled),
+                        text = formatAnnotatedResult(
+                            line.result,
+                            precision,
+                            regionCode,
+                            groupingSeparatorEnabled,
+                            showPrecisionEllipsis,
+                            resultColor
+                        ),
                         style = MaterialTheme.typography.bodyLarge.copy(
                             fontFamily = FiraCodeFamily,
                             fontWeight = FontWeight.Bold

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorViewModel.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorViewModel.kt
@@ -131,7 +131,9 @@ class CalculatorViewModel(
     )
     val syncFolderUri: StateFlow<String?> = _syncFolderUri
 
-    private val _lastSyncAt = MutableStateFlow<Long?>(null)
+    private val _lastSyncAt = MutableStateFlow<Long?>(
+        prefs?.getLong(SyncManager.PREF_LAST_SYNC_AT, 0L)?.takeIf { it > 0L }
+    )
     val lastSyncAt: StateFlow<Long?> = _lastSyncAt
 
     private val _showPrecisionEllipsis = MutableStateFlow(

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorViewModel.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorViewModel.kt
@@ -204,13 +204,15 @@ class CalculatorViewModel(
                 val fileId = when (mode) {
                     LaunchMode.NOT_SET -> null
                     LaunchMode.SCRATCHPAD -> {
-                        // Wait for scratchpad to be ready if it's not yet
-                        var retry = 0
-                        while (_scratchpadFileId.value == null && retry < 10) {
-                            kotlinx.coroutines.delay(100)
-                            retry++
+                        if (!_showScratchpad.value) null else {
+                            // Wait for scratchpad to be ready if it's not yet
+                            var retry = 0
+                            while (_scratchpadFileId.value == null && retry < 10) {
+                                kotlinx.coroutines.delay(100)
+                                retry++
+                            }
+                            _scratchpadFileId.value
                         }
-                        _scratchpadFileId.value
                     }
                     LaunchMode.JOURNAL -> {
                         val today = SimpleDateFormat("yyyy-MM-dd", Locale.US).format(Date())
@@ -415,6 +417,11 @@ class CalculatorViewModel(
     fun setShowScratchpad(show: Boolean) {
         _showScratchpad.value = show
         prefs?.edit()?.putBoolean(Constants.PREF_SHOW_SCRATCHPAD, show)?.apply()
+
+        // If the scratchpad is hidden from home, also ensure it's not set to auto-open on launch
+        if (!show && _launchMode.value == LaunchMode.SCRATCHPAD) {
+            setLaunchMode(LaunchMode.NOT_SET)
+        }
     }
 
     fun setLaunchFileId(fileId: Long?) {

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorViewModel.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorViewModel.kt
@@ -131,10 +131,13 @@ class CalculatorViewModel(
     )
     val syncFolderUri: StateFlow<String?> = _syncFolderUri
 
-    private val _lastSyncAt = MutableStateFlow(
-        prefs?.getLong(SyncManager.PREF_LAST_SYNC_AT, 0L)?.takeIf { it > 0L }
-    )
+    private val _lastSyncAt = MutableStateFlow<Long?>(null)
     val lastSyncAt: StateFlow<Long?> = _lastSyncAt
+
+    private val _showPrecisionEllipsis = MutableStateFlow(
+        prefs?.getBoolean(Constants.PREF_SHOW_PRECISION_ELLIPSIS, false) ?: false
+    )
+    val showPrecisionEllipsis: StateFlow<Boolean> = _showPrecisionEllipsis
 
     // Mutex to ensure atomic recalculation cycles per fileId
     private val calculationMutex = Mutex()
@@ -475,6 +478,11 @@ class CalculatorViewModel(
     fun setShowSymbolsShortcuts(enabled: Boolean) {
         _showSymbolsShortcuts.value = enabled
         prefs?.edit()?.putBoolean(PREF_SHOW_SYMBOLS_SHORTCUTS, enabled)?.apply()
+    }
+
+    fun setShowPrecisionEllipsis(enabled: Boolean) {
+        _showPrecisionEllipsis.value = enabled
+        prefs?.edit()?.putBoolean(Constants.PREF_SHOW_PRECISION_ELLIPSIS, enabled)?.apply()
     }
 
     fun setRationalMode(enabled: Boolean) {

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorViewModel.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorViewModel.kt
@@ -400,18 +400,20 @@ class CalculatorViewModel(
 
     fun setLaunchMode(mode: LaunchMode) {
         _launchMode.value = mode
-        val editor = prefs?.edit() ?: return
-        editor.putString(Constants.PREF_LAUNCH_MODE, mode.prefValue)
-        if (mode != LaunchMode.SPECIFIC_FILE) {
-            editor.remove(Constants.PREF_LAUNCH_FILE_ID)
-            _launchFileId.value = null
-        }
-        editor.apply()
 
         // If switching to SCRATCHPAD auto-open mode, ensure scratchpad is visible on home
         if (mode == LaunchMode.SCRATCHPAD) {
             setShowScratchpad(true)
         }
+
+        val editor = prefs?.edit()
+        if (mode != LaunchMode.SPECIFIC_FILE) {
+            _launchFileId.value = null
+            editor?.remove(Constants.PREF_LAUNCH_FILE_ID)
+        }
+        editor
+            ?.putString(Constants.PREF_LAUNCH_MODE, mode.prefValue)
+            ?.apply()
     }
 
     fun setShowScratchpad(show: Boolean) {
@@ -426,10 +428,13 @@ class CalculatorViewModel(
 
     fun setLaunchFileId(fileId: Long?) {
         _launchFileId.value = fileId
+        if (fileId != null) {
+            setLaunchMode(LaunchMode.SPECIFIC_FILE)
+        }
+
         val prefs = prefs ?: return
         if (fileId != null) {
             prefs.edit().putLong(Constants.PREF_LAUNCH_FILE_ID, fileId).apply()
-            setLaunchMode(LaunchMode.SPECIFIC_FILE)
         } else {
             prefs.edit().remove(Constants.PREF_LAUNCH_FILE_ID).apply()
         }

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorViewModel.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorViewModel.kt
@@ -139,6 +139,11 @@ class CalculatorViewModel(
     )
     val showPrecisionEllipsis: StateFlow<Boolean> = _showPrecisionEllipsis
 
+    private val _showScratchpad = MutableStateFlow(
+        prefs?.getBoolean(Constants.PREF_SHOW_SCRATCHPAD, true) ?: true
+    )
+    val showScratchpad: StateFlow<Boolean> = _showScratchpad
+
     // Mutex to ensure atomic recalculation cycles per fileId
     private val calculationMutex = Mutex()
 
@@ -398,6 +403,16 @@ class CalculatorViewModel(
             _launchFileId.value = null
         }
         editor.apply()
+
+        // If switching to SCRATCHPAD auto-open mode, ensure scratchpad is visible on home
+        if (mode == LaunchMode.SCRATCHPAD) {
+            setShowScratchpad(true)
+        }
+    }
+
+    fun setShowScratchpad(show: Boolean) {
+        _showScratchpad.value = show
+        prefs?.edit()?.putBoolean(Constants.PREF_SHOW_SCRATCHPAD, show)?.apply()
     }
 
     fun setLaunchFileId(fileId: Long?) {

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/home/HomeScreen.kt
@@ -96,7 +96,8 @@ fun HomeScreen(
     launchMode: LaunchMode,
     autoOpenFileId: Long?,
     isAutoOpenReady: Boolean,
-    suppressAutoOpenScratchpad: Boolean = false
+    suppressAutoOpenScratchpad: Boolean = false,
+    showScratchpad: Boolean = true
 ) {
     val context = LocalContext.current
     val files by viewModel.allFiles.collectAsState(initial = emptyList())
@@ -206,11 +207,28 @@ fun HomeScreen(
             )
         },
         floatingActionButton = {
-            FloatingActionButton(
-                onClick = { createFile() },
-                containerColor = MaterialTheme.colorScheme.primary
+            Column(
+                horizontalAlignment = Alignment.End,
+                verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
-                Icon(Icons.Default.Add, contentDescription = "New Calculation")
+                if (showScratchpad) {
+                    scratchpadFileId?.let { id ->
+                        FloatingActionButton(
+                            onClick = { onFileClick(id) },
+                            containerColor = MaterialTheme.colorScheme.primaryContainer,
+                            contentColor = MaterialTheme.colorScheme.onPrimaryContainer
+                        ) {
+                            Icon(Icons.Default.FlashOn, contentDescription = "Open temporary scratchpad")
+                        }
+                    }
+                }
+
+                FloatingActionButton(
+                    onClick = { createFile() },
+                    containerColor = MaterialTheme.colorScheme.primary
+                ) {
+                    Icon(Icons.Default.Add, contentDescription = "New Calculation")
+                }
             }
         },
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
@@ -264,16 +282,18 @@ fun HomeScreen(
                             textAlign = TextAlign.Center,
                             modifier = Modifier.padding(bottom = 20.dp)
                         )
-                        scratchpadFileId?.let { id ->
-                            OutlinedButton(
-                                onClick = { onFileClick(id) },
-                                modifier = Modifier.fillMaxWidth()
-                            ) {
-                                Icon(Icons.Default.FlashOn, contentDescription = null)
-                                Spacer(modifier = Modifier.width(8.dp))
-                                Text("Open Scratchpad")
+                        if (showScratchpad) {
+                            scratchpadFileId?.let { id ->
+                                OutlinedButton(
+                                    onClick = { onFileClick(id) },
+                                    modifier = Modifier.fillMaxWidth()
+                                ) {
+                                    Icon(Icons.Default.FlashOn, contentDescription = null)
+                                    Spacer(modifier = Modifier.width(8.dp))
+                                    Text("Open temporary scratchpad")
+                                }
+                                Spacer(modifier = Modifier.height(10.dp))
                             }
-                            Spacer(modifier = Modifier.height(10.dp))
                         }
                         Button(
                             onClick = { createFile() },
@@ -329,7 +349,6 @@ fun HomeScreen(
                             visiblePinnedFiles = visiblePinnedFiles,
                             visibleUnpinnedFiles = visibleUnpinnedFiles,
                             excludedFileIds = excludedFileIds,
-                            scratchpadFileId = scratchpadFileId,
                             onFileClick = onFileClick,
                             coroutineScope = coroutineScope,
                             snackbarHostState = snackbarHostState,
@@ -342,7 +361,6 @@ fun HomeScreen(
                         visiblePinnedFiles = visiblePinnedFiles,
                         visibleUnpinnedFiles = visibleUnpinnedFiles,
                         excludedFileIds = excludedFileIds,
-                        scratchpadFileId = scratchpadFileId,
                         onFileClick = onFileClick,
                         coroutineScope = coroutineScope,
                         snackbarHostState = snackbarHostState,
@@ -360,7 +378,6 @@ private fun HomeFileList(
     visiblePinnedFiles: List<FileEntity>,
     visibleUnpinnedFiles: List<FileEntity>,
     excludedFileIds: Set<Long>,
-    scratchpadFileId: Long?,
     onFileClick: (Long) -> Unit,
     coroutineScope: CoroutineScope,
     snackbarHostState: SnackbarHostState,
@@ -371,56 +388,6 @@ private fun HomeFileList(
         modifier = Modifier.fillMaxSize(),
         contentPadding = PaddingValues(bottom = 96.dp)
     ) {
-        scratchpadFileId?.let { id ->
-            item {
-                SectionHeader(title = "Quick Access")
-                Card(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 8.dp)
-                        .clip(MaterialTheme.shapes.medium)
-                        .clickable { onFileClick(id) },
-                    colors = CardDefaults.cardColors(
-                        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
-                    ),
-                    elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
-                ) {
-                    Row(
-                        modifier = Modifier
-                            .padding(16.dp)
-                            .fillMaxWidth(),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Box(
-                            modifier = Modifier
-                                .size(40.dp)
-                                .clip(RoundedCornerShape(8.dp))
-                                .background(MaterialTheme.colorScheme.primaryContainer),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Icon(
-                                imageVector = Icons.Default.FlashOn,
-                                contentDescription = null,
-                                tint = MaterialTheme.colorScheme.onPrimaryContainer
-                            )
-                        }
-                        Spacer(modifier = Modifier.width(16.dp))
-                        Column {
-                            Text(
-                                text = Constants.SCRATCHPAD_DISPLAY_NAME,
-                                style = MaterialTheme.typography.titleMedium,
-                                color = MaterialTheme.colorScheme.onSurface
-                            )
-                            Text(
-                                text = "Temporary file • Changes not saved",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        }
-                    }
-                }
-            }
-        }
 
         if (visiblePinnedFiles.isNotEmpty()) {
             item { SectionHeader(title = "Pinned") }

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/settings/SettingsScreen.kt
@@ -418,7 +418,6 @@ fun SettingsScreen(
                 modifier = Modifier.padding(horizontal = 56.dp).padding(bottom = 8.dp)
             )
 
-
             if (launchMode != LaunchMode.SCRATCHPAD) {
                 SettingsToggleItem(
                     icon = Icons.Default.FlashOn,

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/settings/SettingsScreen.kt
@@ -55,6 +55,7 @@ import androidx.compose.material.icons.filled.Sync
 import androidx.compose.material.icons.filled.SpaceBar
 import androidx.compose.material.icons.filled.BorderHorizontal
 import androidx.compose.material.icons.filled.Public
+import androidx.compose.material.icons.filled.MoreHoriz
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CenterAlignedTopAppBar
@@ -140,6 +141,8 @@ fun SettingsScreen(
     onRationalModeChange: (Boolean) -> Unit,
     groupingSeparatorEnabled: Boolean,
     onGroupingSeparatorEnabledChange: (Boolean) -> Unit,
+    showPrecisionEllipsis: Boolean,
+    onShowPrecisionEllipsisChange: (Boolean) -> Unit,
     launchMode: LaunchMode,
     onLaunchModeChange: (LaunchMode) -> Unit,
     launchFileId: Long?,
@@ -379,6 +382,40 @@ fun SettingsScreen(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.padding(horizontal = 56.dp).padding(bottom = 8.dp)
             )
+
+            SettingsToggleItem(
+                icon = Icons.Default.MoreHoriz,
+                title = "Truncate too precise numbers with ellipsis",
+                subtitle = "Show ellipsis (e.g., 0.123…) for results with more decimal places than the current precision setting.",
+                checked = showPrecisionEllipsis,
+                onCheckedChange = onShowPrecisionEllipsisChange
+            )
+
+            val mutedEllipsisColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+            Text(
+                text = remember(showPrecisionEllipsis, precision, mutedEllipsisColor) {
+                    val base = "0.12345678901"
+                    val formatted = MathEngine.formatDisplayResult(
+                        base,
+                        precision,
+                        showEllipsis = showPrecisionEllipsis
+                    )
+                    buildAnnotatedString {
+                        if (showPrecisionEllipsis && formatted.endsWith("…")) {
+                            append(formatted.dropLast(1))
+                            withStyle(SpanStyle(color = mutedEllipsisColor, fontWeight = FontWeight.Normal)) {
+                                append("…")
+                            }
+                        } else {
+                            append(formatted)
+                        }
+                    }
+                },
+                style = MaterialTheme.typography.labelMedium.copy(fontFamily = FiraCodeFamily),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 56.dp).padding(bottom = 8.dp)
+            )
+
 
             SettingsDropdownItem(
                 icon = when (launchMode) {

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/settings/SettingsScreen.kt
@@ -147,6 +147,8 @@ fun SettingsScreen(
     onLaunchModeChange: (LaunchMode) -> Unit,
     launchFileId: Long?,
     onLaunchFileIdChange: (Long?) -> Unit,
+    showScratchpad: Boolean,
+    onShowScratchpadChange: (Boolean) -> Unit,
     allFiles: List<FileEntity>,
     onAutoValidateLaunchFile: () -> Unit,
     onValidateLaunchFile: (Long, (Boolean) -> Unit) -> Unit,
@@ -416,6 +418,16 @@ fun SettingsScreen(
                 modifier = Modifier.padding(horizontal = 56.dp).padding(bottom = 8.dp)
             )
 
+
+            if (launchMode != LaunchMode.SCRATCHPAD) {
+                SettingsToggleItem(
+                    icon = Icons.Default.FlashOn,
+                    title = "Show temporary scratchpad shortcut on home",
+                    subtitle = "Always show a bolt icon on the home screen to quickly open the temporary scratchpad.",
+                    checked = showScratchpad,
+                    onCheckedChange = onShowScratchpadChange
+                )
+            }
 
             SettingsDropdownItem(
                 icon = when (launchMode) {

--- a/app/src/test/java/com/vishaltelangre/nerdcalci/core/MathEngineTest.kt
+++ b/app/src/test/java/com/vishaltelangre/nerdcalci/core/MathEngineTest.kt
@@ -1806,27 +1806,6 @@ class MathEngineTest {
     }
 
     @Test
-    fun `formatDisplayResult supports precision ellipsis`() = runBlocking {
-        val locale = Locale.US
-        val value = "1.2345678"
-
-        // Without ellipsis (should round HALF_UP)
-        assertEquals("1.23", MathEngine.formatDisplayResult(value, 2, locale, "US", showEllipsis = false))
-        assertEquals("1.235", MathEngine.formatDisplayResult(value, 3, locale, "US", showEllipsis = false))
-
-        // With ellipsis (should round DOWN and append …)
-        assertEquals("1.23…", MathEngine.formatDisplayResult(value, 2, locale, "US", showEllipsis = true))
-        assertEquals("1.234…", MathEngine.formatDisplayResult(value, 3, locale, "US", showEllipsis = true))
-
-        // With unit
-        assertEquals("1.23… kg", MathEngine.formatDisplayResult(value + " kg", 2, locale, "US", showEllipsis = true))
-
-        // No truncation = no ellipsis
-        assertEquals("1.23", MathEngine.formatDisplayResult("1.23", 2, locale, "US", showEllipsis = true))
-        assertEquals("1.23 kg", MathEngine.formatDisplayResult("1.23 kg", 2, locale, "US", showEllipsis = true))
-    }
-
-    @Test
     fun `getErrorDetails handles undefined variable`() = testCalculate("x + 5") { result ->
         assertError("Unknown variable `x`", result[0], result, 0)
     }

--- a/app/src/test/java/com/vishaltelangre/nerdcalci/core/MathEngineTest.kt
+++ b/app/src/test/java/com/vishaltelangre/nerdcalci/core/MathEngineTest.kt
@@ -1806,6 +1806,27 @@ class MathEngineTest {
     }
 
     @Test
+    fun `formatDisplayResult supports precision ellipsis`() = runBlocking {
+        val locale = Locale.US
+        val value = "1.2345678"
+
+        // Without ellipsis (should round HALF_UP)
+        assertEquals("1.23", MathEngine.formatDisplayResult(value, 2, locale, "US", showEllipsis = false))
+        assertEquals("1.235", MathEngine.formatDisplayResult(value, 3, locale, "US", showEllipsis = false))
+
+        // With ellipsis (should round DOWN and append …)
+        assertEquals("1.23…", MathEngine.formatDisplayResult(value, 2, locale, "US", showEllipsis = true))
+        assertEquals("1.234…", MathEngine.formatDisplayResult(value, 3, locale, "US", showEllipsis = true))
+
+        // With unit
+        assertEquals("1.23… kg", MathEngine.formatDisplayResult(value + " kg", 2, locale, "US", showEllipsis = true))
+
+        // No truncation = no ellipsis
+        assertEquals("1.23", MathEngine.formatDisplayResult("1.23", 2, locale, "US", showEllipsis = true))
+        assertEquals("1.23 kg", MathEngine.formatDisplayResult("1.23 kg", 2, locale, "US", showEllipsis = true))
+    }
+
+    @Test
     fun `getErrorDetails handles undefined variable`() = testCalculate("x + 5") { result ->
         assertError("Unknown variable `x`", result[0], result, 0)
     }

--- a/app/src/test/java/com/vishaltelangre/nerdcalci/core/PrecisionEllipsisTest.kt
+++ b/app/src/test/java/com/vishaltelangre/nerdcalci/core/PrecisionEllipsisTest.kt
@@ -42,6 +42,17 @@ class PrecisionEllipsisTest {
     }
 
     @Test
+    fun `standard notation ellipsis - truncated negative`() {
+        val result = engine.formatDisplayResult(
+            rawResult = "-1.23456",
+            precision = 2,
+            showEllipsis = true
+        )
+        // -1.23456 truncated to 2 decimals with DOWN rounding (towards zero) -> -1.23
+        assertEquals("-1.23…", result)
+    }
+
+    @Test
     fun `standard notation ellipsis - exact`() {
         val result = engine.formatDisplayResult(
             rawResult = "1.23",
@@ -110,5 +121,16 @@ class PrecisionEllipsisTest {
         )
         // 1.23456E2 -> 1.23E2...
         assertEquals("1.23E2…", result)
+    }
+
+    @Test
+    fun `scientific notation ellipsis - truncated negative`() {
+        val result = engine.formatDisplayResult(
+            rawResult = "-1.23456E2",
+            precision = 2,
+            showEllipsis = true
+        )
+        // -1.23456E2 -> -1.23E2...
+        assertEquals("-1.23E2…", result)
     }
 }

--- a/app/src/test/java/com/vishaltelangre/nerdcalci/core/PrecisionEllipsisTest.kt
+++ b/app/src/test/java/com/vishaltelangre/nerdcalci/core/PrecisionEllipsisTest.kt
@@ -8,6 +8,20 @@ import java.util.Locale
 class PrecisionEllipsisTest {
 
     private val engine = MathEngine
+    private val locale = Locale.US
+    private val region = "US"
+
+    private fun format(
+        rawResult: String,
+        precision: Int,
+        showEllipsis: Boolean = true
+    ) = engine.formatDisplayResult(
+        rawResult = rawResult,
+        precision = precision,
+        systemLocale = locale,
+        regionCode = region,
+        showEllipsis = showEllipsis
+    )
 
     @Test
     fun `formatDisplayResult supports precision ellipsis`() = runBlocking {
@@ -32,7 +46,7 @@ class PrecisionEllipsisTest {
 
     @Test
     fun `standard notation ellipsis - truncated`() {
-        val result = engine.formatDisplayResult(
+        val result = format(
             rawResult = "1.23456",
             precision = 2,
             showEllipsis = true
@@ -43,7 +57,7 @@ class PrecisionEllipsisTest {
 
     @Test
     fun `standard notation ellipsis - truncated negative`() {
-        val result = engine.formatDisplayResult(
+        val result = format(
             rawResult = "-1.23456",
             precision = 2,
             showEllipsis = true
@@ -54,7 +68,7 @@ class PrecisionEllipsisTest {
 
     @Test
     fun `standard notation ellipsis - exact`() {
-        val result = engine.formatDisplayResult(
+        val result = format(
             rawResult = "1.23",
             precision = 2,
             showEllipsis = true
@@ -66,7 +80,7 @@ class PrecisionEllipsisTest {
     fun `scientific notation ellipsis - truncated large number`() {
         // 1.23456E15 with precision 2
         // Mantissa 1.23456 truncated to 1.23
-        val result = engine.formatDisplayResult(
+        val result = format(
             rawResult = "1234560000000000",
             precision = 2,
             showEllipsis = true
@@ -77,7 +91,7 @@ class PrecisionEllipsisTest {
 
     @Test
     fun `scientific notation ellipsis - exact large number`() {
-        val result = engine.formatDisplayResult(
+        val result = format(
             rawResult = "1230000000000000",
             precision = 2,
             showEllipsis = true
@@ -88,7 +102,7 @@ class PrecisionEllipsisTest {
     @Test
     fun `scientific notation ellipsis - truncated small number`() {
         // 0.000123456 -> 1.23456E-4
-        val result = engine.formatDisplayResult(
+        val result = format(
             rawResult = "0.000123456",
             precision = 2,
             showEllipsis = true
@@ -104,7 +118,7 @@ class PrecisionEllipsisTest {
         // 9.999 != 10.0 -> truncated = true
         // Then roundingMode = DOWN (because showEllipsis = true)
         // formatScientific(9.999E15, precision 1, DOWN) -> 9.9E15
-        val result = engine.formatDisplayResult(
+        val result = format(
             rawResult = "9999000000000000",
             precision = 1,
             showEllipsis = true
@@ -114,7 +128,7 @@ class PrecisionEllipsisTest {
 
     @Test
     fun `scientific notation ellipsis - forced by E notation in input`() {
-        val result = engine.formatDisplayResult(
+        val result = format(
             rawResult = "1.23456E2",
             precision = 2,
             showEllipsis = true
@@ -125,7 +139,7 @@ class PrecisionEllipsisTest {
 
     @Test
     fun `scientific notation ellipsis - truncated negative`() {
-        val result = engine.formatDisplayResult(
+        val result = format(
             rawResult = "-1.23456E2",
             precision = 2,
             showEllipsis = true

--- a/app/src/test/java/com/vishaltelangre/nerdcalci/core/PrecisionEllipsisTest.kt
+++ b/app/src/test/java/com/vishaltelangre/nerdcalci/core/PrecisionEllipsisTest.kt
@@ -1,0 +1,114 @@
+package com.vishaltelangre.nerdcalci.core
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.util.Locale
+
+class PrecisionEllipsisTest {
+
+    private val engine = MathEngine
+
+    @Test
+    fun `formatDisplayResult supports precision ellipsis`() = runBlocking {
+        val locale = Locale.US
+        val value = "1.2345678"
+
+        // Without ellipsis (should round HALF_UP)
+        assertEquals("1.23", engine.formatDisplayResult(value, 2, locale, "US", showEllipsis = false))
+        assertEquals("1.235", engine.formatDisplayResult(value, 3, locale, "US", showEllipsis = false))
+
+        // With ellipsis (should round DOWN and append …)
+        assertEquals("1.23…", engine.formatDisplayResult(value, 2, locale, "US", showEllipsis = true))
+        assertEquals("1.234…", engine.formatDisplayResult(value, 3, locale, "US", showEllipsis = true))
+
+        // With unit
+        assertEquals("1.23… kg", engine.formatDisplayResult(value + " kg", 2, locale, "US", showEllipsis = true))
+
+        // No truncation = no ellipsis
+        assertEquals("1.23", engine.formatDisplayResult("1.23", 2, locale, "US", showEllipsis = true))
+        assertEquals("1.23 kg", engine.formatDisplayResult("1.23 kg", 2, locale, "US", showEllipsis = true))
+    }
+
+    @Test
+    fun `standard notation ellipsis - truncated`() {
+        val result = engine.formatDisplayResult(
+            rawResult = "1.23456",
+            precision = 2,
+            showEllipsis = true
+        )
+        // 1.23456 truncated to 2 decimals with DOWN rounding (because showEllipsis=true) -> 1.23
+        assertEquals("1.23…", result)
+    }
+
+    @Test
+    fun `standard notation ellipsis - exact`() {
+        val result = engine.formatDisplayResult(
+            rawResult = "1.23",
+            precision = 2,
+            showEllipsis = true
+        )
+        assertEquals("1.23", result)
+    }
+
+    @Test
+    fun `scientific notation ellipsis - truncated large number`() {
+        // 1.23456E15 with precision 2
+        // Mantissa 1.23456 truncated to 1.23
+        val result = engine.formatDisplayResult(
+            rawResult = "1234560000000000",
+            precision = 2,
+            showEllipsis = true
+        )
+        // 1.23456E15 -> 1.23E15...
+        assertEquals("1.23E15…", result)
+    }
+
+    @Test
+    fun `scientific notation ellipsis - exact large number`() {
+        val result = engine.formatDisplayResult(
+            rawResult = "1230000000000000",
+            precision = 2,
+            showEllipsis = true
+        )
+        assertEquals("1.23E15", result)
+    }
+
+    @Test
+    fun `scientific notation ellipsis - truncated small number`() {
+        // 0.000123456 -> 1.23456E-4
+        val result = engine.formatDisplayResult(
+            rawResult = "0.000123456",
+            precision = 2,
+            showEllipsis = true
+        )
+        assertEquals("1.23E-4…", result)
+    }
+
+    @Test
+    fun `scientific notation ellipsis - rounding up mantissa to 10`() {
+        // 9.999E15 with precision 1
+        // Mantissa 9.999 rounded HALF_UP to 1 decimal is 10.0
+        // isScientificTruncated uses HALF_UP to detect truncation.
+        // 9.999 != 10.0 -> truncated = true
+        // Then roundingMode = DOWN (because showEllipsis = true)
+        // formatScientific(9.999E15, precision 1, DOWN) -> 9.9E15
+        val result = engine.formatDisplayResult(
+            rawResult = "9999000000000000",
+            precision = 1,
+            showEllipsis = true
+        )
+        assertEquals("9.9E15…", result)
+    }
+
+    @Test
+    fun `scientific notation ellipsis - forced by E notation in input`() {
+        val result = engine.formatDisplayResult(
+            rawResult = "1.23456E2",
+            precision = 2,
+            showEllipsis = true
+        )
+        // 1.23456E2 -> 1.23E2...
+        assertEquals("1.23E2…", result)
+    }
+}

--- a/app/src/test/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorViewModelTest.kt
+++ b/app/src/test/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorViewModelTest.kt
@@ -1,9 +1,11 @@
 package com.vishaltelangre.nerdcalci.ui.calculator
 
 import android.util.Log
+import android.content.SharedPreferences
 import com.vishaltelangre.nerdcalci.data.local.FakeCalculatorDao
 import com.vishaltelangre.nerdcalci.data.local.entities.FileEntity
 import com.vishaltelangre.nerdcalci.data.local.entities.LineEntity
+import com.vishaltelangre.nerdcalci.data.sync.SyncManager
 import io.mockk.*
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
@@ -150,5 +152,18 @@ class CalculatorViewModelTest {
         assertEquals(1, allFiles.size)
         assertEquals("Normal", allFiles[0].name)
         assertTrue(allFiles.none { it.isTemporary })
+    }
+    @Test
+    fun `lastSyncAt is initialized from SharedPreferences`() = runTest {
+        // Given: SharedPreferences has a last sync timestamp
+        val expectedTimestamp = 123456789L
+        val mockPrefs = mockk<SharedPreferences>(relaxed = true)
+        every { mockPrefs.getLong(SyncManager.PREF_LAST_SYNC_AT, 0L) } returns expectedTimestamp
+
+        // When: ViewModel is created with these prefs
+        val testViewModel = CalculatorViewModel(fakeDao, mockPrefs)
+
+        // Then: lastSyncAt should reflect the stored timestamp
+        assertEquals(expectedTimestamp, testViewModel.lastSyncAt.value)
     }
 }

--- a/fastlane/metadata/android/en-US/changelogs/360.txt
+++ b/fastlane/metadata/android/en-US/changelogs/360.txt
@@ -1,0 +1,3 @@
+- Added a global setting to show an ellipsis for truncated numbers that exceed the configured result precision (Issue #106).
+- Added a toggle to show/hide the temporary scratchpad shortcut on the home screen via a new bolt icon (Issue #109).
+- Fixed an issue where changing "Auto-open a file on launch" settings caused unintended navigation.

--- a/fastlane/metadata/android/en-US/changelogs/360.txt
+++ b/fastlane/metadata/android/en-US/changelogs/360.txt
@@ -1,3 +1,4 @@
 - Added a global setting to show an ellipsis for truncated numbers that exceed the configured result precision (Issue #106).
 - Added a toggle to show/hide the temporary scratchpad shortcut on the home screen via a new bolt icon (Issue #109).
 - Fixed an issue where changing "Auto-open a file on launch" settings caused unintended navigation.
+- Fixed an issue where the calculator's last sync time was not persisted across application restarts.


### PR DESCRIPTION
- Fixes #106.
- Fixes #109.

Released in version [v3.6.0](https://github.com/vishaltelangre/NerdCalci/releases/tag/v3.6.0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to show an ellipsis (…) for numeric results truncated beyond the configured precision (settings preview included)
  * Added a home-screen toggle (bolt icon) to show/hide the temporary scratchpad shortcut

* **Bug Fixes**
  * Fixed unintended navigation when changing the "Auto-open a file on launch" setting
  * Fixed calculator's last sync time not persisting across restarts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->