### PR TITLE
Preventing local state updates from overwriting the text field

### DIFF
--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorScreen.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorScreen.kt
@@ -1391,8 +1391,12 @@ private fun LineRow(
         mutableStateOf(TextFieldValue(text = displayText))
     }
 
-    // Track the last expression and version sent to the ViewModel to prevent race conditions
-    // between local state and database updates during rapid typing.
+
+    var isFocused by remember { mutableStateOf(false) }
+    val isFocusedRef = remember { derivedStateOf { isFocused } }
+
+    // Track the last expression and version sent to the ViewModel.
+    // Used only for the unfocused sync path — not for stale-echo detection while typing.
     var lastSentExpression by remember(line.id) { mutableStateOf<String?>(null) }
     var lastSentVersion by remember(line.id) { mutableStateOf(line.version) }
 
@@ -1422,7 +1426,7 @@ private fun LineRow(
             isNonFirstLine = lineNumber > 1
         )
     }
-    var isFocused by remember { mutableStateOf(false) }
+
     val focusRequester = remember { FocusRequester() }
 
     // Autocomplete suggestions
@@ -1628,20 +1632,16 @@ private fun LineRow(
 
     // Sync with database updates
     LaunchedEffect(line.expression, line.version, lineNumber) {
-        // Only update local state if the database version is newer than or equal to what we last sent,
-        // or if the field is not focused (meaning it's an external update like a recalculation).
-        // This prevents "echo" updates from the database from overwriting the current text field
-        // during rapid typing, which is the root cause of cursor synchronization issues.
-        val isStaleEcho = isFocused && line.version < lastSentVersion
+        // Hard bail: never overwrite local state while the user is typing.
+        if (isFocusedRef.value) return@LaunchedEffect
 
-        if (!isStaleEcho && (line.expression != lastSentExpression || textFieldValue.text != displayText)) {
-            val selection = TextRange(
-                textFieldValue.selection.start.coerceIn(0, displayText.length),
-                textFieldValue.selection.end.coerceIn(0, displayText.length)
-            )
+        val newDisplayText = if (lineNumber > 1) " " + line.expression else line.expression
+        if (textFieldValue.text != newDisplayText) {
+            val clampedStart = textFieldValue.selection.start.coerceIn(0, newDisplayText.length)
+            val clampedEnd = textFieldValue.selection.end.coerceIn(0, newDisplayText.length)
             textFieldValue = textFieldValue.copy(
-                text = displayText,
-                selection = selection
+                text = newDisplayText,
+                selection = TextRange(clampedStart, clampedEnd)
             )
             // Sync our local tracking with the actual DB state
             lastSentExpression = line.expression

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorScreen.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorScreen.kt
@@ -1631,9 +1631,9 @@ private fun LineRow(
     }
 
     // Sync with database updates
-    LaunchedEffect(line.expression, line.version, lineNumber) {
+    LaunchedEffect(line.expression, line.version, lineNumber, isFocused) {
         // Hard bail: never overwrite local state while the user is typing.
-        if (isFocusedRef.value) return@LaunchedEffect
+        if (isFocused) return@LaunchedEffect
 
         val newDisplayText = if (lineNumber > 1) " " + line.expression else line.expression
         if (textFieldValue.text != newDisplayText) {

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorScreen.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorScreen.kt
@@ -1393,7 +1393,6 @@ private fun LineRow(
 
 
     var isFocused by remember { mutableStateOf(false) }
-    val isFocusedRef = remember { derivedStateOf { isFocused } }
 
     // Track the last expression and version sent to the ViewModel.
     // Used only for the unfocused sync path — not for stale-echo detection while typing.
@@ -1635,12 +1634,11 @@ private fun LineRow(
         // Hard bail: never overwrite local state while the user is typing.
         if (isFocused) return@LaunchedEffect
 
-        val newDisplayText = if (lineNumber > 1) " " + line.expression else line.expression
-        if (textFieldValue.text != newDisplayText) {
-            val clampedStart = textFieldValue.selection.start.coerceIn(0, newDisplayText.length)
-            val clampedEnd = textFieldValue.selection.end.coerceIn(0, newDisplayText.length)
+        if (textFieldValue.text != displayText) {
+            val clampedStart = textFieldValue.selection.start.coerceIn(0, displayText.length)
+            val clampedEnd = textFieldValue.selection.end.coerceIn(0, displayText.length)
             textFieldValue = textFieldValue.copy(
-                text = newDisplayText,
+                text = displayText,
                 selection = TextRange(clampedStart, clampedEnd)
             )
             // Sync our local tracking with the actual DB state


### PR DESCRIPTION
Preventing local state updates from overwriting the text is focused to avoid "echo" effects and cursor jumping during rapid typing

* Refactor focus tracking using `derivedStateOf` for more reliable state checks within synchronization effects

* Simplify synchronization logic to strictly bail out if the field is focused, ensuring local user input takes precedence over database updates

* Ensure correct text selection clamping when applying external updates to non-focused lines

Issue https://github.com/vishaltelangre/NerdCalci/issues/105

https://github.com/user-attachments/assets/e957a00a-bad3-4889-bbca-254a313323e1



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented calculator input from being overwritten while the user is actively typing.
  * Simplified synchronization so updates only apply when display text truly differs from stored data.
  * Preserved cursor/selection during sync by clamping selection to the current display length.
  * Removed unreliable stale/echo gating so typing is no longer interrupted by prior sync state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->