### PR TITLE
Add plural aliases for numeral multipliers and support quadrillion and quintillion scales

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -844,15 +844,17 @@ em = 20
 
 NerdCalci expands numeric representations supporting standard numeral naming conventions efficiently with scalable word suffixes:
 
-| Word       | Multiplier          | Example      | Evaluates to |
-| :--------- | :------------------ | :----------- | :----------- |
-| `hundred`  | `100`               | `5 hundred`  | `500`        |
-| `thousand` | `1,000`             | `2 thousand` | `2000`       |
-| `lakh`     | `100,000`           | `10 lakh`    | `1000000`    |
-| `million`  | `1,000,000`         | `5 million`  | `5000000`    |
-| `crore`    | `10,000,000`        | `1.5 crore`  | `15000000`   |
-| `billion`  | `1,000,000,000`     | `1 billion`  | `1000000000` |
-| `trillion` | `1,000,000,000,000` | `1 trillion` | `1E12`       |
+| Word (Aliases)                | Multiplier                  | Example         | Evaluates to |
+| :---------------------------- | :-------------------------- | :-------------- | :----------- |
+| `hundred`, `hundreds`         | `100`                       | `5 hundreds`    | `500`        |
+| `thousand`, `thousands`       | `1,000`                     | `2 thousands`   | `2000`       |
+| `lakh`, `lakhs`               | `100,000`                   | `10 lakhs`      | `1000000`    |
+| `million`, `millions`         | `1,000,000`                 | `5 millions`    | `5000000`    |
+| `crore`, `crores`             | `10,000,000`                | `1.5 crores`    | `15000000`   |
+| `billion`, `billions`         | `1,000,000,000`             | `1 billion`     | `1000000000` |
+| `trillion`, `trillions`       | `1,000,000,000,000`         | `1 trillion`    | `1E12`       |
+| `quadrillion`, `quadrillions` | `1,000,000,000,000,000`     | `1 quadrillion` | `1E15`       |
+| `quintillion`, `quintillions` | `1,000,000,000,000,000,000` | `1 quintillion` | `1E18`       |
 
 ### Radix base conversions
 

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/Parser.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/Parser.kt
@@ -585,13 +585,15 @@ class Parser(private val tokens: List<Token>) {
 
     private fun getNumeralMultiplier(word: String): BigDecimal? {
         return when (word.lowercase()) {
-            "hundred" -> BigDecimal("100")
-            "thousand" -> BigDecimal("1000")
-            "lakh" -> BigDecimal("100000")
-            "million" -> BigDecimal("1000000")
-            "crore" -> BigDecimal("10000000")
-            "billion" -> BigDecimal("1000000000")
-            "trillion" -> BigDecimal("1000000000000")
+            "hundred", "hundreds" -> BigDecimal("100")
+            "thousand", "thousands" -> BigDecimal("1000")
+            "lakh", "lakhs" -> BigDecimal("100000")
+            "million", "millions" -> BigDecimal("1000000")
+            "crore", "crores" -> BigDecimal("10000000")
+            "billion", "billions" -> BigDecimal("1000000000")
+            "trillion", "trillions" -> BigDecimal("1000000000000")
+            "quadrillion", "quadrillions" -> BigDecimal("1e15")
+            "quintillion", "quintillions" -> BigDecimal("1e18")
             else -> null
         }
     }

--- a/app/src/test/java/com/vishaltelangre/nerdcalci/core/MathEngineTest.kt
+++ b/app/src/test/java/com/vishaltelangre/nerdcalci/core/MathEngineTest.kt
@@ -379,6 +379,64 @@ class MathEngineTest {
     }
 
     @Test
+    fun `all numeral multiplier aliases evaluate correctly`() = testCalculate(
+        "5 hundred", "raw(5 hundred)", "5 hundreds", "raw(5 hundreds)",
+        "5 thousand", "raw(5 thousand)", "5 thousands", "raw(5 thousands)",
+        "5 lakh", "raw(5 lakh)", "5 lakhs", "raw(5 lakhs)",
+        "5 million", "raw(5 million)", "5 millions", "raw(5 millions)",
+        "5 crore", "raw(5 crore)", "5 crores", "raw(5 crores)",
+        "5 billion", "raw(5 billion)", "5 billions", "raw(5 billions)",
+        "5 trillion", "raw(5 trillion)", "5 trillions", "raw(5 trillions)",
+        "1 quadrillion", "raw(1 quadrillion)", "1 quadrillions", "raw(1 quadrillions)",
+        "1 quintillion", "raw(1 quintillion)", "1 quintillions", "raw(1 quintillions)"
+    ) { result ->
+        assertEquals("500.0", result[0].result)
+        assertEquals("500", result[1].result)
+        assertEquals("500.0", result[2].result)
+        assertEquals("500", result[3].result)
+
+        assertEquals("5000.0", result[4].result)
+        assertEquals("5000", result[5].result)
+        assertEquals("5000.0", result[6].result)
+        assertEquals("5000", result[7].result)
+
+        assertEquals("500000.0", result[8].result)
+        assertEquals("500000", result[9].result)
+        assertEquals("500000.0", result[10].result)
+        assertEquals("500000", result[11].result)
+
+        assertEquals("5000000.0", result[12].result)
+        assertEquals("5000000", result[13].result)
+        assertEquals("5000000.0", result[14].result)
+        assertEquals("5000000", result[15].result)
+
+        assertEquals("50000000.0", result[16].result)
+        assertEquals("50000000", result[17].result)
+        assertEquals("50000000.0", result[18].result)
+        assertEquals("50000000", result[19].result)
+
+        assertEquals("5000000000.0", result[20].result)
+        assertEquals("5000000000", result[21].result)
+        assertEquals("5000000000.0", result[22].result)
+        assertEquals("5000000000", result[23].result)
+
+        assertEquals("5000000000000.0", result[24].result)
+        assertEquals("5000000000000", result[25].result)
+        assertEquals("5000000000000.0", result[26].result)
+        assertEquals("5000000000000", result[27].result)
+
+        assertEquals("1.0E15", result[28].result)
+        assertEquals("1000000000000000", result[29].result)
+        assertEquals("1.0E15", result[30].result)
+        assertEquals("1000000000000000", result[31].result)
+
+        assertEquals("1.0E18", result[32].result)
+        assertEquals("1000000000000000000", result[33].result)
+        assertEquals("1.0E18", result[34].result)
+        assertEquals("1000000000000000000", result[35].result)
+    }
+
+    @Test
     fun `decimal addition returns formatted result`() = testCalculate("1.5 + 2.3") { result ->
         assertEquals("3.8", result[0].result)
     }


### PR DESCRIPTION
Before

<img width="300" alt="2026-04-13_22-04" src="https://github.com/user-attachments/assets/e38c88a3-29ea-4d12-987f-65be4d68a373" />

After

<img width="300" alt="2026-04-13_22-17" src="https://github.com/user-attachments/assets/11871b90-25d9-456c-a8f1-13b12a40b97f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Support for plural forms of numeral multipliers (hundreds, thousands, lakhs, millions, crores, billions, trillions).
  * Extended support for quadrillions and quintillions scales.

* **Documentation**
  * Updated numeral systems reference with plural forms and larger scale examples.

* **Tests**
  * Added comprehensive test coverage for numeral multiplier aliases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->