### PR TITLE
Add setting to disable result precision and other misc bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.8.6] - 2026-04-25
+### Added
+- Added a toggle to turn off "Result precision" to see full unrounded results (Issue #134).
+
+### Fixed
+- Fixed a bug that could cause the app to hang when toggling Rational Mode on certain scientific notation inputs.
+- Fixed the result precision ellipsis (`…`) styling for results with units (e.g., `(1/3) km`).
+
 ## [3.8.5] - 2026-04-22
 ### Fixed
 - Fixed app crash when using the power operator (`^`) on devices running Android versions earlier than 12 (Issue #152).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
     defaultConfig {
         applicationId = "com.vishaltelangre.nerdcalci"
         minSdk = 23
-        versionCode = 385
-        versionName = "3.8.5"
+        versionCode = 386
+        versionName = "3.8.6"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/Builtins.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/Builtins.kt
@@ -141,7 +141,7 @@ object Builtins {
         ): EvaluationResult {
             val input = args.first()
             val value = input.value ?: BigDecimal.ZERO
-            val rational = Rational.fromBigDecimalSmart(value) ?: return input.copy(value = value, explicitRational = false)
+            val rational = Rational.fromBigDecimalSmart(value) ?: return input.copy(value = value, explicitRational = false, rationalValue = null)
             return input.copy(value = value, rationalValue = rational, explicitRational = true)
         }
     }

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/Builtins.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/Builtins.kt
@@ -141,7 +141,7 @@ object Builtins {
         ): EvaluationResult {
             val input = args.first()
             val value = input.value ?: BigDecimal.ZERO
-            val rational = Rational.fromBigDecimalSmart(value)
+            val rational = Rational.fromBigDecimalSmart(value) ?: return input.copy(value = value, explicitRational = false)
             return input.copy(value = value, rationalValue = rational, explicitRational = true)
         }
     }

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/Constants.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/Constants.kt
@@ -49,6 +49,7 @@ object Constants {
     const val DEFAULT_PRECISION = 2
     const val MIN_PRECISION = 0
     const val MAX_PRECISION = 10
+    const val PRECISION_OFF = -1
 
     const val SYNC_ENGINE_RATIONAL_MODE = "rational_mode"
     const val DEFAULT_RATIONAL_MODE = false

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/Evaluator.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/Evaluator.kt
@@ -55,7 +55,7 @@ class Evaluator(
 
             val baseRational = baseEval.rationalValue ?: Rational.toRational(base)
             val percentRational = Rational.toRational(expr.percent.divide(BigDecimal("100"), mc))
-            EvaluationResult(resultValue, resultUnit, rationalValue = baseRational * percentRational)
+            EvaluationResult(resultValue, resultUnit, rationalValue = applyRationalOp(baseRational, TokenKind.STAR, percentRational))
         }
         is Expr.PercentOff     -> {
             val baseEval = evaluate(expr.base)
@@ -66,14 +66,14 @@ class Evaluator(
             val resultValue = base.multiply(factor)
 
             val baseRational = baseEval.rationalValue ?: Rational.toRational(base)
-            val factorRational = Rational.ONE - Rational.toRational(expr.percent.divide(BigDecimal("100"), mc))
-            EvaluationResult(resultValue, resultUnit, rationalValue = baseRational * factorRational)
+            val factorRational = applyRationalOp(Rational.ONE, TokenKind.MINUS, Rational.toRational(expr.percent.divide(BigDecimal("100"), mc)))
+            EvaluationResult(resultValue, resultUnit, rationalValue = applyRationalOp(baseRational, TokenKind.STAR, factorRational))
         }
         is Expr.UnaryMinus     -> {
             val eval = evaluate(expr.operand)
             val operand = eval.value ?: throw EvalException("Cannot negate a non-numeric value")
             val operandRational = eval.rationalValue ?: Rational.toRational(operand)
-            eval.copy(value = operand.negate(), rationalValue = operandRational.negate())
+            eval.copy(value = operand.negate(), rationalValue = operandRational?.negate())
         }
         is Expr.Variable       -> resolveVariable(expr.name)
         is Expr.FunctionCall   -> evaluateFunction(expr.name, expr.args)
@@ -93,7 +93,7 @@ class Evaluator(
             // We'll keep using BigDecimal for result.value but update rationalValue.
             val resultValue = UnitConverter.toBase(rawValue, unit, variables)
             val baseRational = eval.rationalValue ?: Rational.toRational(rawValue)
-            val resultRationalValue = UnitConverter.toBase(baseRational, unit, variables)
+            val resultRationalValue = baseRational?.let { UnitConverter.toBase(it, unit, variables) }
             EvaluationResult(resultValue, unit.symbols.first(), rationalValue = resultRationalValue)
         }
         is Expr.UnitConversion -> {
@@ -196,7 +196,7 @@ class Evaluator(
 
             val resultValue = UnitConverter.toBase(value, fromUnit, variables)
             val currentRational = eval.rationalValue ?: Rational.toRational(value)
-            val resultRationalValue = UnitConverter.toBase(currentRational, fromUnit, variables)
+            val resultRationalValue = currentRational?.let { UnitConverter.toBase(it, fromUnit, variables) }
             return EvaluationResult(resultValue, toUnit.symbols.first(), rationalValue = resultRationalValue)
         }
 
@@ -375,12 +375,16 @@ class Evaluator(
         result: EvaluationResult,
         unit: NerdUnit?,
         forceDisplayValue: Boolean,
-        rational: Rational
-    ): Rational {
-        if (unit == null) return rational
+        rational: Rational?
+    ): Rational? {
+        if (unit == null || rational == null) return rational
         return when {
             unit.category == UnitCategory.SCALAR -> rational
-            forceDisplayValue || result.explicitUnitless -> UnitConverter.fromBase(rational, unit, variables)
+            forceDisplayValue || result.explicitUnitless -> try {
+                UnitConverter.fromBase(rational, unit, variables)
+            } catch (_: ArithmeticException) {
+                null
+            }
             else -> rational
         }
     }
@@ -399,11 +403,11 @@ class Evaluator(
             val (resultVal, resultRational) = when (expr.op) {
                 TokenKind.PLUS  -> {
                     val factor = BigDecimal.ONE.add(pct.divide(BigDecimal("100"), mc))
-                    leftVal.multiply(factor) to leftRational * (Rational.ONE + pctRational)
+                    leftVal.multiply(factor) to applyRationalOp(leftRational, TokenKind.STAR, applyRationalOp(Rational.ONE, TokenKind.PLUS, pctRational))
                 }
                 TokenKind.MINUS -> {
                     val factor = BigDecimal.ONE.subtract(pct.divide(BigDecimal("100"), mc))
-                    leftVal.multiply(factor) to leftRational * (Rational.ONE - pctRational)
+                    leftVal.multiply(factor) to applyRationalOp(leftRational, TokenKind.STAR, applyRationalOp(Rational.ONE, TokenKind.MINUS, pctRational))
                 }
                 else -> {
                     val rightVal = rightEval.value ?: BigDecimal.ZERO
@@ -445,7 +449,7 @@ class Evaluator(
             val leftRationalScalar = scalarRationalValue(leftEval, leftUnit, leftUsesDisplayValue, leftRational)
             val rightRationalScalar = scalarRationalValue(rightEval, rightUnit, rightUsesDisplayValue, rightRational)
             val resultDisplayRational = applyRationalOp(leftRationalScalar, expr.op, rightRationalScalar)
-            val resultBaseRational = UnitConverter.toBase(resultDisplayRational, tempUnit, variables)
+            val resultBaseRational = resultDisplayRational?.let { UnitConverter.toBase(it, tempUnit, variables) }
 
             return EvaluationResult(
                 resultBase,
@@ -498,10 +502,10 @@ class Evaluator(
                     val rightCanonical = UnitConverter.fromBase(rightVal, canonicalUnit, variables)
                     val resultCanonical = applyOp(leftCanonical, expr.op, rightCanonical)
 
-                    val leftCanonicalRational = UnitConverter.fromBase(leftRational, canonicalUnit, variables)
-                    val rightCanonicalRational = UnitConverter.fromBase(rightRational, canonicalUnit, variables)
+                    val leftCanonicalRational = leftRational?.let { UnitConverter.fromBase(it, canonicalUnit, variables) }
+                    val rightCanonicalRational = rightRational?.let { UnitConverter.fromBase(it, canonicalUnit, variables) }
                     val resultCanonicalRational = applyRationalOp(leftCanonicalRational, expr.op, rightCanonicalRational)
-                    val resultBaseRational = UnitConverter.toBase(resultCanonicalRational, canonicalUnit, variables)
+                    val resultBaseRational = resultCanonicalRational?.let { UnitConverter.toBase(it, canonicalUnit, variables) }
 
                     return EvaluationResult(
                         UnitConverter.toBase(resultCanonical, canonicalUnit, variables),
@@ -610,7 +614,7 @@ class Evaluator(
             }
         }
 
-        return EvaluationResult(resultVal * resultScale, resultUnit, rationalValue = resultRational * Rational.toRational(resultScale))
+        return EvaluationResult(resultVal * resultScale, resultUnit, rationalValue = applyRationalOp(resultRational, TokenKind.STAR, Rational.toRational(resultScale)))
     }
 
     private fun applyOp(left: BigDecimal, op: TokenKind, right: BigDecimal): BigDecimal = when (op) {
@@ -620,10 +624,17 @@ class Evaluator(
         TokenKind.SLASH   -> {
             if (right.compareTo(BigDecimal.ZERO) == 0) throw DivisionByZeroException()
             if (rationalMode) {
-                // In rational mode, we use the rational value for higher precision when possible.
-                // applyRationalOp will be called separately to get the exact value.
-                // Still need a BigDecimal for result.value.
-                (Rational.toRational(left) / Rational.toRational(right)).toBigDecimal(mc)
+                val leftRat = Rational.toRational(left)
+                val rightRat = Rational.toRational(right)
+                if (leftRat != null && rightRat != null) {
+                    try {
+                        (leftRat / rightRat).toBigDecimal(mc)
+                    } catch (_: ArithmeticException) {
+                        left.divide(right, mc)
+                    }
+                } else {
+                    left.divide(right, mc)
+                }
             } else {
                 left.divide(right, mc)
             }
@@ -636,38 +647,46 @@ class Evaluator(
         else -> throw EvalException("Unknown operator: `$op`")
     }
 
-    private fun applyRationalOp(left: Rational, op: TokenKind, right: Rational): Rational = when (op) {
-        TokenKind.PLUS    -> left + right
-        TokenKind.MINUS   -> left - right
-        TokenKind.STAR    -> left * right
-        TokenKind.SLASH   -> if (right.num == BigInteger.ZERO) throw DivisionByZeroException() else left / right
-        TokenKind.PERCENT -> {
-            // Remainder for rationals: a - b * floor(a/b)
-            val div = (left / right).toBigDecimal(mc).setScale(0, RoundingMode.FLOOR)
-            left - (right * Rational.toRational(div))
-        }
-        TokenKind.CARET   -> {
-            val exponentVal = try {
-                right.toBigDecimal(mc).toBigIntegerExact()
-            } catch (e: ArithmeticException) {
-                null
-            }
-
-            if (exponentVal == null || exponentVal.abs() > BigInteger.valueOf(Constants.MAX_EXACT_EXPONENT.toLong())) {
-                // Exponent too large for exact rational power; degrade to approximated BigDecimal
-                val base = left.toBigDecimal(mc)
-                val exponent = right.toBigDecimal(mc)
-                Rational.toRational(applyOp(base, TokenKind.CARET, exponent))
-            } else {
-                val exponent = exponentVal.toInt()
-                if (exponent >= 0) {
-                    Rational(left.num.pow(exponent), left.den.pow(exponent))
-                } else {
-                    Rational(left.den.pow(-exponent), left.num.pow(-exponent))
+    private fun applyRationalOp(left: Rational?, op: TokenKind, right: Rational?): Rational? {
+        if (left == null || right == null) return null
+        return try {
+            when (op) {
+                TokenKind.PLUS    -> left + right
+                TokenKind.MINUS   -> left - right
+                TokenKind.STAR    -> left * right
+                TokenKind.SLASH   -> if (right.num == BigInteger.ZERO) throw DivisionByZeroException() else left / right
+                TokenKind.PERCENT -> {
+                    // Remainder for rationals: a - b * floor(a/b)
+                    val div = (left / right).toBigDecimal(mc).setScale(0, RoundingMode.FLOOR)
+                    val divRat = Rational.toRational(div) ?: return null
+                    left - (right * divRat)
                 }
+                TokenKind.CARET   -> {
+                    val exponentVal = try {
+                        right.toBigDecimal(mc).toBigIntegerExact()
+                    } catch (e: ArithmeticException) {
+                        null
+                    }
+
+                    if (exponentVal == null || exponentVal.abs() > BigInteger.valueOf(Constants.MAX_EXACT_EXPONENT.toLong())) {
+                        // Exponent too large for exact rational power; degrade to approximated BigDecimal
+                        val base = left.toBigDecimal(mc)
+                        val exponent = right.toBigDecimal(mc)
+                        Rational.toRational(applyOp(base, TokenKind.CARET, exponent))
+                    } else {
+                        val exponent = exponentVal.toInt()
+                        if (exponent >= 0) {
+                            Rational(left.num.pow(exponent), left.den.pow(exponent))
+                        } else {
+                            Rational(left.den.pow(-exponent), left.num.pow(-exponent))
+                        }
+                    }
+                }
+                else -> throw EvalException("Unknown operator: `$op`")
             }
+        } catch (_: ArithmeticException) {
+            null
         }
-        else -> throw EvalException("Unknown operator: `$op`")
     }
 
 

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/Evaluator.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/Evaluator.kt
@@ -656,15 +656,15 @@ class Evaluator(
                 TokenKind.STAR    -> left * right
                 TokenKind.SLASH   -> if (right.num == BigInteger.ZERO) throw DivisionByZeroException() else left / right
                 TokenKind.PERCENT -> {
-                    // Remainder for rationals: a - b * floor(a/b)
-                    val div = (left / right).toBigDecimal(mc).setScale(0, RoundingMode.FLOOR)
+                    // Remainder for rationals: a - b * trunc(a/b)
+                    val div = (left / right).toBigDecimal(mc).setScale(0, RoundingMode.DOWN)
                     val divRat = Rational.toRational(div) ?: return null
                     left - (right * divRat)
                 }
                 TokenKind.CARET   -> {
                     val exponentVal = try {
                         right.toBigDecimal(mc).toBigIntegerExact()
-                    } catch (e: ArithmeticException) {
+                    } catch (_: ArithmeticException) {
                         null
                     }
 

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/MathEngine.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/MathEngine.kt
@@ -511,23 +511,11 @@ object MathEngine {
 
         val value = numStr.toBigDecimalOrNull() ?: return rawResult
 
-        if (precision == Constants.PRECISION_OFF) {
-            val trimmedUnit = unitStr.trim().lowercase()
-            val isNumeralSystem = UnitConverter.isNumeralSystemSymbol(trimmedUnit)
-            return if (isNumeralSystem) {
-                if (value.remainder(BigDecimal.ONE).compareTo(BigDecimal.ZERO) != 0) "Err"
-                formatNumeralSystem(value.toLong(), when (trimmedUnit) {
-                    "bin" -> 2
-                    "hex" -> 16
-                    "oct" -> 8
-                    else -> 10
-                }) + unitStr
-            } else {
-                formatBigDecimal(value) + unitStr
-            }
+        val safePrecision = if (precision == Constants.PRECISION_OFF) {
+            value.stripTrailingZeros().scale().coerceAtLeast(0)
+        } else {
+            precision.coerceIn(Constants.MIN_PRECISION, Constants.MAX_PRECISION)
         }
-
-        val safePrecision = precision.coerceIn(Constants.MIN_PRECISION, Constants.MAX_PRECISION)
 
         val trimmedUnit = unitStr.trim().lowercase()
         val isNumeralSystem = UnitConverter.isNumeralSystemSymbol(trimmedUnit)
@@ -542,29 +530,35 @@ object MathEngine {
             }
             formatNumeralSystem(value.toLong(), radix) to false
         } else {
-            val roundsToZero = value.signum() != 0 && safePrecision > 0 &&
+            val roundsToZero = value.signum() != 0 && precision != Constants.PRECISION_OFF && safePrecision > 0 &&
                     value.abs() < BigDecimal("0.5").movePointLeft(safePrecision)
             val isScientific = numStr.contains('E', ignoreCase = true) ||
                     value.abs() >= BigDecimal("1000000000000000") || // 10^15
                     (value.abs() < BigDecimal("0.001") && value.signum() != 0) ||
                     roundsToZero
 
-            val truncated = if (isScientific) {
-                isScientificTruncated(value, safePrecision)
-            } else {
-                value.compareTo(value.setScale(safePrecision, java.math.RoundingMode.HALF_UP)) != 0
+            val truncated = if (precision == Constants.PRECISION_OFF) false else {
+                if (isScientific) {
+                    isScientificTruncated(value, safePrecision)
+                } else {
+                    value.compareTo(value.setScale(safePrecision, java.math.RoundingMode.HALF_UP)) != 0
+                }
             }
 
             val roundingMode = if (truncated && showEllipsis) java.math.RoundingMode.DOWN else java.math.RoundingMode.HALF_UP
 
             val formatted = if (isScientific) {
-                formatScientific(value, safePrecision, locale, roundingMode)
+                val scientificSafePrecision = if (precision == Constants.PRECISION_OFF) {
+                    if (value.remainder(BigDecimal.ONE).compareTo(BigDecimal.ZERO) == 0) 1 else safePrecision
+                } else safePrecision
+                formatScientific(value, scientificSafePrecision, locale, roundingMode)
             } else {
                 val useIndianStyle = regionCode == "IN" ||
                         (regionCode == RegionUtils.SYSTEM_DEFAULT && locale.country == "IN")
                 val isWholeNumber = value.remainder(BigDecimal.ONE).compareTo(BigDecimal.ZERO) == 0
-                val forcePrecision = !isWholeNumber // Only force trailing zeros for actual decimals
-                formatLocalized(value, safePrecision, locale, alwaysDecimal = false, forcePrecision = forcePrecision, useIndianStyle = useIndianStyle, groupingSeparatorEnabled = groupingSeparatorEnabled, roundingMode = roundingMode)
+                val forcePrecision = if (precision == Constants.PRECISION_OFF) false else !isWholeNumber
+                val alwaysDecimal = if (precision == Constants.PRECISION_OFF) isWholeNumber else false
+                formatLocalized(value, safePrecision, locale, alwaysDecimal = alwaysDecimal, forcePrecision = forcePrecision, useIndianStyle = useIndianStyle, groupingSeparatorEnabled = groupingSeparatorEnabled, roundingMode = roundingMode)
             }
             formatted to truncated
         }

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/MathEngine.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/MathEngine.kt
@@ -249,10 +249,10 @@ object MathEngine {
                     } else {
                         val formattedValue = if (!result.forceFloat && (isolatedContext.rationalMode || result.explicitRational)) {
                             if (result.rationalValue != null) {
-                                UnitConverter.fromBase(result.rationalValue, u, isolatedContext.variables).toString()
+                                UnitConverter.fromBase(result.rationalValue, u, isolatedContext.variables)?.toString() ?: formatBigDecimal(UnitConverter.fromBase(result.value, u, isolatedContext.variables))
                             } else {
                                 val displayValue = UnitConverter.fromBase(result.value, u, isolatedContext.variables)
-                                Rational.fromBigDecimalSmart(displayValue).toString()
+                                Rational.fromBigDecimalSmart(displayValue)?.toString() ?: formatBigDecimal(displayValue)
                             }
                         } else {
                             val displayValue = UnitConverter.fromBase(result.value, u, isolatedContext.variables).let { value ->
@@ -266,7 +266,7 @@ object MathEngine {
                     if (result.rationalValue != null) {
                         result.rationalValue.toString()
                     } else {
-                        Rational.fromBigDecimalSmart(result.value).toString()
+                        Rational.fromBigDecimalSmart(result.value)?.toString() ?: formatBigDecimal(result.value)
                     }
                 } else if (result.explicitUnitless && result.value.remainder(BigDecimal.ONE).compareTo(BigDecimal.ZERO) == 0) {
                     result.value.toLong().toString()

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/MathEngine.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/MathEngine.kt
@@ -549,7 +549,10 @@ object MathEngine {
 
             val formatted = if (isScientific) {
                 val scientificSafePrecision = if (precision == Constants.PRECISION_OFF) {
-                    if (value.remainder(BigDecimal.ONE).compareTo(BigDecimal.ZERO) == 0) 1 else safePrecision
+                    if (value.remainder(BigDecimal.ONE).compareTo(BigDecimal.ZERO) == 0) {
+                        val strippedPrecision = value.stripTrailingZeros().precision()
+                        maxOf(1, strippedPrecision)
+                    } else safePrecision
                 } else safePrecision
                 formatScientific(value, scientificSafePrecision, locale, roundingMode)
             } else {

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/MathEngine.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/MathEngine.kt
@@ -510,6 +510,23 @@ object MathEngine {
         }
 
         val value = numStr.toBigDecimalOrNull() ?: return rawResult
+
+        if (precision == Constants.PRECISION_OFF) {
+            val trimmedUnit = unitStr.trim().lowercase()
+            val isNumeralSystem = UnitConverter.isNumeralSystemSymbol(trimmedUnit)
+            return if (isNumeralSystem) {
+                if (value.remainder(BigDecimal.ONE).compareTo(BigDecimal.ZERO) != 0) "Err"
+                formatNumeralSystem(value.toLong(), when (trimmedUnit) {
+                    "bin" -> 2
+                    "hex" -> 16
+                    "oct" -> 8
+                    else -> 10
+                }) + unitStr
+            } else {
+                formatBigDecimal(value) + unitStr
+            }
+        }
+
         val safePrecision = precision.coerceIn(Constants.MIN_PRECISION, Constants.MAX_PRECISION)
 
         val trimmedUnit = unitStr.trim().lowercase()

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/Rational.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/Rational.kt
@@ -8,16 +8,19 @@ import java.math.MathContext as JavaMathContext
  * Represents a rational number (fraction) with an exact numerator and denominator.
  * Automatically simplifies the fraction by dividing both by their greatest common divisor (GCD).
  */
-data class Rational(private val initialNumerator: BigInteger, private val initialDenominator: BigInteger) {
+class Rational(numerator: BigInteger, denominator: BigInteger) : Comparable<Rational> {
     val num: BigInteger
     val den: BigInteger
 
     init {
-        require(initialDenominator != BigInteger.ZERO) { "Denominator cannot be zero" }
-        val gcd = initialNumerator.abs().gcd(initialDenominator.abs())
-        val sign = if (initialDenominator.signum() < 0) -1 else 1
-        num = (initialNumerator / gcd) * BigInteger.valueOf(sign.toLong())
-        den = (initialDenominator / gcd) * BigInteger.valueOf(sign.toLong())
+        require(denominator != BigInteger.ZERO) { "Denominator cannot be zero" }
+        if (isTooComplex(numerator, denominator)) {
+            throw ArithmeticException("Rational number is too complex")
+        }
+        val gcd = numerator.abs().gcd(denominator.abs())
+        val sign = if (denominator.signum() < 0) -1 else 1
+        num = (numerator / gcd) * BigInteger.valueOf(sign.toLong())
+        den = (denominator / gcd) * BigInteger.valueOf(sign.toLong())
     }
 
     operator fun plus(other: Rational): Rational {
@@ -53,22 +56,64 @@ data class Rational(private val initialNumerator: BigInteger, private val initia
 
     fun isWhole(): Boolean = den == BigInteger.ONE
 
+    fun toLongOrNull(): Long? {
+        if (!isWhole()) return null
+        if (num > BigInteger.valueOf(Long.MAX_VALUE) || num < BigInteger.valueOf(Long.MIN_VALUE)) return null
+        return num.toLong()
+    }
+
     override fun toString(): String {
         return if (isWhole()) num.toString() else "$num/$den"
     }
 
+    override fun compareTo(other: Rational): Int {
+        return (num * other.den).compareTo(other.num * den)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is Rational) return false
+        return num == other.num && den == other.den
+    }
+
+    override fun hashCode(): Int {
+        var result = num.hashCode()
+        result = 31 * result + den.hashCode()
+        return result
+    }
+
     companion object {
+        private const val MAX_RATIONAL_BIT_LENGTH = 16000 // approx 4.8k digits
+        private const val MAX_EXACT_EXPONENT = 10000
+
+        internal fun isTooComplex(numerator: BigInteger, denominator: BigInteger): Boolean {
+            return numerator.bitLength() > MAX_RATIONAL_BIT_LENGTH ||
+                    denominator.bitLength() > MAX_RATIONAL_BIT_LENGTH
+        }
+
         val ZERO = Rational(BigInteger.ZERO, BigInteger.ONE)
         val ONE = Rational(BigInteger.ONE, BigInteger.ONE)
 
-        fun toRational(value: BigDecimal): Rational {
+        fun toRational(value: BigDecimal): Rational? {
             val scale = value.scale()
-            return if (scale <= 0) {
-                Rational(value.toBigIntegerExact(), BigInteger.ONE)
-            } else {
-                val numerator = value.unscaledValue()
-                val denominator = BigInteger.TEN.pow(scale)
-                Rational(numerator, denominator)
+            // Quick check for extreme scales before any heavy calculation
+            if (scale > MAX_EXACT_EXPONENT || scale < -MAX_EXACT_EXPONENT) {
+                return null
+            }
+
+            return try {
+                if (scale <= 0) {
+                    val result = value.toBigIntegerExact()
+                    if (isTooComplex(result, BigInteger.ONE)) null
+                    else Rational(result, BigInteger.ONE)
+                } else {
+                    val numerator = value.unscaledValue()
+                    val denominator = BigInteger.TEN.pow(scale)
+                    if (isTooComplex(numerator, denominator)) null
+                    else Rational(numerator, denominator)
+                }
+            } catch (_: Exception) {
+                null
             }
         }
 
@@ -82,7 +127,7 @@ data class Rational(private val initialNumerator: BigInteger, private val initia
         fun fromBigDecimalSmart(
             value: BigDecimal, 
             tolerance: BigDecimal = BigDecimal("1e-15")
-        ): Rational {
+        ): Rational? {
             val sign = value.signum()
             val absoluteValue = value.abs()
             
@@ -94,26 +139,41 @@ data class Rational(private val initialNumerator: BigInteger, private val initia
             var currentVal = absoluteValue
             
             for (i in 0..100) { // Limit iterations to prevent infinite loops for truly irrational numbers
-                val a = currentVal.toBigInteger()
+                val a = try { currentVal.toBigInteger() } catch (_: Exception) { break }
                 val nextN = a * n1 + n2
                 val nextD = a * d1 + d2
                 
+                if (isTooComplex(nextN, nextD)) break
+
                 // Update for next iteration
                 n2 = n1
                 d2 = d1
                 n1 = nextN
                 d1 = nextD
                 
-                val currentRational = Rational(n1, d1)
+                val currentRational = try { Rational(n1, d1) } catch (_: Exception) { break }
                 val diff = (currentRational.toBigDecimal(JavaMathContext.DECIMAL128) - absoluteValue).abs()
                 if (diff <= tolerance && !(n1 == BigInteger.ZERO && absoluteValue.signum() > 0)) break
                 
                 val fractionalPart = currentVal - a.toBigDecimal()
                 if (fractionalPart.signum() == 0) break
-                currentVal = BigDecimal.ONE.divide(fractionalPart, JavaMathContext.DECIMAL128)
+                currentVal = try {
+                    BigDecimal.ONE.divide(fractionalPart, JavaMathContext.DECIMAL128)
+                } catch (_: Exception) {
+                    break
+                }
             }
             
-            return if (sign >= 0) Rational(n1, d1) else Rational(n1.negate(), d1)
+            if (d1 == BigInteger.ZERO) return null 
+            if (isTooComplex(n1, d1)) return null
+            
+            val result = if (sign >= 0) Rational(n1, d1) else Rational(n1.negate(), d1)
+            // If the approximation resulted in zero but the original value was not zero,
+            // it means the number is too small to be represented as a "simple" rational 
+            // within our complexity limits. Fall back to BigDecimal.
+            if (result.num.signum() == 0 && value.signum() != 0) return null
+            
+            return result
         }
     }
 }

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/UnitConverter.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/UnitConverter.kt
@@ -34,7 +34,7 @@ data class Unit(
     val customRationalToBase: ((Rational, Map<String, EvaluationResult>) -> Rational)? = null,
     val customRationalFromBase: ((Rational, Map<String, EvaluationResult>) -> Rational)? = null
 ) {
-    val factorRational: Rational = rationalFactor ?: Rational.toRational(factor)
+    val factorRational: Rational? = rationalFactor ?: Rational.toRational(factor)
 }
 
 object UnitConverter {
@@ -513,12 +513,16 @@ object UnitConverter {
         return unit.customToBase?.invoke(value, variables) ?: value.multiply(unit.factor)
     }
 
-    fun toBase(value: Rational, unit: Unit, variables: Map<String, EvaluationResult>): Rational {
+    fun toBase(value: Rational, unit: Unit, variables: Map<String, EvaluationResult>): Rational? {
         unit.customRationalToBase?.let { return it(value, variables) }
         unit.customToBase?.let {
             return Rational.fromBigDecimalSmart(it(value.toBigDecimal(JavaMathContext.DECIMAL128), variables))
         }
-        return value * unit.factorRational
+        return try {
+            value * (unit.factorRational ?: return null)
+        } catch (_: ArithmeticException) {
+            null
+        }
     }
 
     fun fromBase(value: BigDecimal, unit: Unit, variables: Map<String, EvaluationResult>): BigDecimal {
@@ -529,12 +533,16 @@ object UnitConverter {
         }
     }
 
-    fun fromBase(value: Rational, unit: Unit, variables: Map<String, EvaluationResult>): Rational {
+    fun fromBase(value: Rational, unit: Unit, variables: Map<String, EvaluationResult>): Rational? {
         unit.customRationalFromBase?.let { return it(value, variables) }
         unit.customFromBase?.let {
             return Rational.fromBigDecimalSmart(it(value.toBigDecimal(JavaMathContext.DECIMAL128), variables))
         }
-        return value / unit.factorRational
+        return try {
+            value / (unit.factorRational ?: return null)
+        } catch (_: ArithmeticException) {
+            null
+        }
     }
 
     fun convert(value: BigDecimal, from: Unit, to: Unit, variables: Map<String, EvaluationResult>): BigDecimal {
@@ -551,15 +559,15 @@ object UnitConverter {
         return convert(value, from, to, variables)
     }
 
-    fun convert(value: Rational, from: Unit, to: Unit, variables: Map<String, EvaluationResult>): Rational {
+    fun convert(value: Rational, from: Unit, to: Unit, variables: Map<String, EvaluationResult>): Rational? {
         if (from.category != to.category) {
             throw EvalException("Conversion of `${from.name}` to `${to.name}` is not supported")
         }
-        val baseValue = toBase(value, from, variables)
+        val baseValue = toBase(value, from, variables) ?: return null
         return fromBase(baseValue, to, variables)
     }
 
-    fun convert(value: Rational, fromToken: String, toToken: String, variables: Map<String, EvaluationResult>): Rational {
+    fun convert(value: Rational, fromToken: String, toToken: String, variables: Map<String, EvaluationResult>): Rational? {
         val from = findUnit(fromToken) ?: throw EvalException("Unknown unit `$fromToken`")
         val to = findUnit(toToken) ?: throw EvalException("Unknown unit `$toToken`")
         return convert(value, from, to, variables)

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/UnitConverter.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/UnitConverter.kt
@@ -514,11 +514,11 @@ object UnitConverter {
     }
 
     fun toBase(value: Rational, unit: Unit, variables: Map<String, EvaluationResult>): Rational? {
-        unit.customRationalToBase?.let { return it(value, variables) }
-        unit.customToBase?.let {
-            return Rational.fromBigDecimalSmart(it(value.toBigDecimal(JavaMathContext.DECIMAL128), variables))
-        }
         return try {
+            unit.customRationalToBase?.let { return it(value, variables) }
+            unit.customToBase?.let {
+                return Rational.fromBigDecimalSmart(it(value.toBigDecimal(JavaMathContext.DECIMAL128), variables))
+            }
             value * (unit.factorRational ?: return null)
         } catch (_: ArithmeticException) {
             null
@@ -534,11 +534,11 @@ object UnitConverter {
     }
 
     fun fromBase(value: Rational, unit: Unit, variables: Map<String, EvaluationResult>): Rational? {
-        unit.customRationalFromBase?.let { return it(value, variables) }
-        unit.customFromBase?.let {
-            return Rational.fromBigDecimalSmart(it(value.toBigDecimal(JavaMathContext.DECIMAL128), variables))
-        }
         return try {
+            unit.customRationalFromBase?.let { return it(value, variables) }
+            unit.customFromBase?.let {
+                return Rational.fromBigDecimalSmart(it(value.toBigDecimal(JavaMathContext.DECIMAL128), variables))
+            }
             value / (unit.factorRational ?: return null)
         } catch (_: ArithmeticException) {
             null

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorScreen.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorScreen.kt
@@ -1305,11 +1305,13 @@ private fun formatAnnotatedResult(
 ): AnnotatedString {
     val formatted = formatResult(text, precision, regionCode, groupingSeparatorEnabled, showPrecisionEllipsis)
     return buildAnnotatedString {
-        if (showPrecisionEllipsis && formatted.endsWith("…")) {
-            append(formatted.dropLast(1))
+        val ellipsisIndex = formatted.indexOf('…')
+        if (showPrecisionEllipsis && ellipsisIndex != -1) {
+            append(formatted.substring(0, ellipsisIndex))
             withStyle(SpanStyle(color = resultColor.copy(alpha = 0.5f), fontWeight = FontWeight.Normal)) {
                 append("…")
             }
+            append(formatted.substring(ellipsisIndex + 1))
         } else {
             append(formatted)
         }

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorViewModel.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorViewModel.kt
@@ -124,8 +124,9 @@ class CalculatorViewModel(
     val isScratchpadReady: StateFlow<Boolean> = _isScratchpadReady
 
     private val _precision = MutableStateFlow(
-        (prefs?.getInt(Constants.SYNC_ENGINE_PRECISION, Constants.DEFAULT_PRECISION) ?: Constants.DEFAULT_PRECISION)
-            .coerceIn(Constants.MIN_PRECISION, Constants.MAX_PRECISION)
+        prefs?.getInt(Constants.SYNC_ENGINE_PRECISION, Constants.DEFAULT_PRECISION)
+            ?.let { if (it == Constants.PRECISION_OFF) Constants.PRECISION_OFF else it.coerceIn(Constants.MIN_PRECISION, Constants.MAX_PRECISION) }
+            ?: Constants.DEFAULT_PRECISION
     )
     val precision: StateFlow<Int> = _precision
 
@@ -527,9 +528,13 @@ class CalculatorViewModel(
     }
  
     fun setPrecision(precision: Int) {
-        val clampedPrecision = precision.coerceIn(Constants.MIN_PRECISION, Constants.MAX_PRECISION)
-        _precision.value = clampedPrecision
-        prefs?.edit()?.putInt(Constants.SYNC_ENGINE_PRECISION, clampedPrecision)?.apply()
+        val resolvedPrecision = if (precision == Constants.PRECISION_OFF) {
+            Constants.PRECISION_OFF
+        } else {
+            precision.coerceIn(Constants.MIN_PRECISION, Constants.MAX_PRECISION)
+        }
+        _precision.value = resolvedPrecision
+        prefs?.edit()?.putInt(Constants.SYNC_ENGINE_PRECISION, resolvedPrecision)?.apply()
     }
 
     fun setShowLineNumbers(enabled: Boolean) {

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/settings/CalculatorSettingsScreen.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/settings/CalculatorSettingsScreen.kt
@@ -69,7 +69,8 @@ fun CalculatorSettingsScreen(
     onBack: () -> Unit
 ) {
     var showRegionDialog by remember { mutableStateOf(false) }
-    var sliderValue by remember(precision) { mutableStateOf(if (precision == Constants.PRECISION_OFF) Constants.DEFAULT_PRECISION.toFloat() else precision.toFloat()) }
+    var lastPrecision by remember { mutableStateOf(if (precision == Constants.PRECISION_OFF) Constants.DEFAULT_PRECISION else precision) }
+    var sliderValue by remember(precision) { mutableStateOf(if (precision == Constants.PRECISION_OFF) lastPrecision.toFloat() else precision.toFloat()) }
     var editorFontSizeSlider by remember(editorFontSize) { mutableStateOf(editorFontSize) }
     val availableRegions = remember { RegionUtils.getAvailableRegions() }
 
@@ -104,8 +105,8 @@ fun CalculatorSettingsScreen(
                 checked = precision != Constants.PRECISION_OFF,
                 onCheckedChange = { enabled ->
                     if (enabled) {
-                        sliderValue = Constants.DEFAULT_PRECISION.toFloat()
-                        onPrecisionChange(Constants.DEFAULT_PRECISION)
+                        sliderValue = lastPrecision.toFloat()
+                        onPrecisionChange(lastPrecision)
                     } else {
                         onPrecisionChange(Constants.PRECISION_OFF)
                     }
@@ -117,7 +118,10 @@ fun CalculatorSettingsScreen(
                     icon = Icons.Default.Info,
                     title = "Decimal places",
                     value = sliderValue,
-                    onValueChange = { sliderValue = it },
+                    onValueChange = {
+                        sliderValue = it
+                        lastPrecision = it.roundToInt()
+                    },
                     onValueChangeFinished = { onPrecisionChange(sliderValue.roundToInt()) },
                     valueRange = Constants.MIN_PRECISION.toFloat()..Constants.MAX_PRECISION.toFloat(),
                     steps = Constants.MAX_PRECISION - Constants.MIN_PRECISION - 1,
@@ -171,38 +175,40 @@ fun CalculatorSettingsScreen(
                 modifier = Modifier.padding(horizontal = 80.dp).padding(bottom = 16.dp)
             )
 
-            SettingsToggleItem(
-                icon = Icons.Default.MoreHoriz,
-                title = "Truncate with ellipsis",
-                subtitle = "Show ellipsis (e.g., 0.123…) for results with more decimal places than the current precision setting.",
-                checked = showPrecisionEllipsis,
-                onCheckedChange = onShowPrecisionEllipsisChange
-            )
+            if (precision != Constants.PRECISION_OFF) {
+                SettingsToggleItem(
+                    icon = Icons.Default.MoreHoriz,
+                    title = "Truncate with ellipsis",
+                    subtitle = "Show ellipsis (e.g., 0.123…) for results with more decimal places than the current precision setting.",
+                    checked = showPrecisionEllipsis,
+                    onCheckedChange = onShowPrecisionEllipsisChange
+                )
 
-            val mutedEllipsisColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
-            Text(
-                text = remember(showPrecisionEllipsis, precision, mutedEllipsisColor) {
-                    val base = "0.12345678901"
-                    val formatted = MathEngine.formatDisplayResult(
-                        base,
-                        precision,
-                        showEllipsis = showPrecisionEllipsis
-                    )
-                    buildAnnotatedString {
-                        if (showPrecisionEllipsis && formatted.endsWith("…")) {
-                            append(formatted.dropLast(1))
-                            withStyle(SpanStyle(color = mutedEllipsisColor, fontWeight = FontWeight.Normal)) {
-                                append("…")
+                val mutedEllipsisColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+                Text(
+                    text = remember(showPrecisionEllipsis, precision, mutedEllipsisColor) {
+                        val base = "0.12345678901"
+                        val formatted = MathEngine.formatDisplayResult(
+                            base,
+                            precision,
+                            showEllipsis = showPrecisionEllipsis
+                        )
+                        buildAnnotatedString {
+                            if (showPrecisionEllipsis && formatted.endsWith("…")) {
+                                append(formatted.dropLast(1))
+                                withStyle(SpanStyle(color = mutedEllipsisColor, fontWeight = FontWeight.Normal)) {
+                                    append("…")
+                                }
+                            } else {
+                                append(formatted)
                             }
-                        } else {
-                            append(formatted)
                         }
-                    }
-                },
-                style = MaterialTheme.typography.labelLarge.copy(fontFamily = FiraCodeFamily),
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(horizontal = 56.dp).padding(bottom = 16.dp)
-            )
+                    },
+                    style = MaterialTheme.typography.labelLarge.copy(fontFamily = FiraCodeFamily),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 56.dp).padding(bottom = 16.dp)
+                )
+            }
 
             SettingsSection(title = "Editor")
 

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/settings/CalculatorSettingsScreen.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/settings/CalculatorSettingsScreen.kt
@@ -69,7 +69,7 @@ fun CalculatorSettingsScreen(
     onBack: () -> Unit
 ) {
     var showRegionDialog by remember { mutableStateOf(false) }
-    var sliderValue by remember(precision) { mutableStateOf(precision.toFloat()) }
+    var sliderValue by remember(precision) { mutableStateOf(if (precision == Constants.PRECISION_OFF) Constants.DEFAULT_PRECISION.toFloat() else precision.toFloat()) }
     var editorFontSizeSlider by remember(editorFontSize) { mutableStateOf(editorFontSize) }
     val availableRegions = remember { RegionUtils.getAvailableRegions() }
 
@@ -97,16 +97,34 @@ fun CalculatorSettingsScreen(
         ) {
             SettingsSection(title = "Math logic")
 
-            SettingsSliderItem(
+            SettingsToggleItem(
                 icon = Icons.Default.Info,
                 title = "Result precision",
-                value = sliderValue,
-                onValueChange = { sliderValue = it },
-                onValueChangeFinished = { onPrecisionChange(sliderValue.roundToInt()) },
-                valueRange = Constants.MIN_PRECISION.toFloat()..Constants.MAX_PRECISION.toFloat(),
-                steps = Constants.MAX_PRECISION - Constants.MIN_PRECISION - 1,
-                valueFormatter = { "${it.roundToInt()} decimal places" }
+                subtitle = "Limit decimal places in results. Turn off to show full precision.",
+                checked = precision != Constants.PRECISION_OFF,
+                onCheckedChange = { enabled ->
+                    if (enabled) {
+                        sliderValue = Constants.DEFAULT_PRECISION.toFloat()
+                        onPrecisionChange(Constants.DEFAULT_PRECISION)
+                    } else {
+                        onPrecisionChange(Constants.PRECISION_OFF)
+                    }
+                }
             )
+
+            if (precision != Constants.PRECISION_OFF) {
+                SettingsSliderItem(
+                    icon = Icons.Default.Info,
+                    title = "Decimal places",
+                    value = sliderValue,
+                    onValueChange = { sliderValue = it },
+                    onValueChangeFinished = { onPrecisionChange(sliderValue.roundToInt()) },
+                    valueRange = Constants.MIN_PRECISION.toFloat()..Constants.MAX_PRECISION.toFloat(),
+                    steps = Constants.MAX_PRECISION - Constants.MIN_PRECISION - 1,
+                    valueFormatter = { "${it.roundToInt()} decimal places" },
+                    modifier = Modifier.padding(start = 24.dp)
+                )
+            }
 
             SettingsToggleItem(
                 icon = Icons.Default.BorderHorizontal,
@@ -135,7 +153,8 @@ fun CalculatorSettingsScreen(
                 title = "Show grouping separators",
                 subtitle = null,
                 checked = groupingSeparatorEnabled,
-                onCheckedChange = onGroupingSeparatorEnabledChange
+                onCheckedChange = onGroupingSeparatorEnabledChange,
+                modifier = Modifier.padding(start = 24.dp)
             )
 
             Text(
@@ -149,7 +168,7 @@ fun CalculatorSettingsScreen(
                 },
                 style = MaterialTheme.typography.labelLarge.copy(fontFamily = FiraCodeFamily),
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(horizontal = 56.dp).padding(bottom = 16.dp)
+                modifier = Modifier.padding(horizontal = 80.dp).padding(bottom = 16.dp)
             )
 
             SettingsToggleItem(

--- a/app/src/test/java/com/vishaltelangre/nerdcalci/core/MathEngineTest.kt
+++ b/app/src/test/java/com/vishaltelangre/nerdcalci/core/MathEngineTest.kt
@@ -1831,12 +1831,15 @@ class MathEngineTest {
 
     @Test
     fun `formatDisplayResult shows full precision when precision is off`() = runBlocking {
-        assertEquals("7.1234", MathEngine.formatDisplayResult("7.1234", Constants.PRECISION_OFF))
-        assertEquals("1234.5678", MathEngine.formatDisplayResult("1234.5678", Constants.PRECISION_OFF))
-        assertEquals("0.3333333333333333", MathEngine.formatDisplayResult("0.3333333333333333", Constants.PRECISION_OFF))
-        assertEquals("10.0", MathEngine.formatDisplayResult("10", Constants.PRECISION_OFF))
-        assertEquals("1.0E20", MathEngine.formatDisplayResult("1.0E20", Constants.PRECISION_OFF))
-        assertEquals("5.1234 km", MathEngine.formatDisplayResult("5.1234 km", Constants.PRECISION_OFF))
+        assertEquals("7.1234", MathEngine.formatDisplayResult("7.1234", Constants.PRECISION_OFF, java.util.Locale.ROOT))
+        // Verify grouping and locale awareness
+        assertEquals("1,234.5678", MathEngine.formatDisplayResult("1234.5678", Constants.PRECISION_OFF, java.util.Locale.US))
+        assertEquals("1.234,5678", MathEngine.formatDisplayResult("1234.5678", Constants.PRECISION_OFF, java.util.Locale.GERMANY))
+        
+        assertEquals("0.3333333333333333", MathEngine.formatDisplayResult("0.3333333333333333", Constants.PRECISION_OFF, java.util.Locale.ROOT))
+        assertEquals("10.0", MathEngine.formatDisplayResult("10", Constants.PRECISION_OFF, java.util.Locale.ROOT))
+        assertEquals("1.0E20", MathEngine.formatDisplayResult("1.0E20", Constants.PRECISION_OFF, java.util.Locale.ROOT))
+        assertEquals("5.1234 km", MathEngine.formatDisplayResult("5.1234 km", Constants.PRECISION_OFF, java.util.Locale.ROOT))
     }
 
     @Test

--- a/app/src/test/java/com/vishaltelangre/nerdcalci/core/MathEngineTest.kt
+++ b/app/src/test/java/com/vishaltelangre/nerdcalci/core/MathEngineTest.kt
@@ -1824,9 +1824,19 @@ class MathEngineTest {
     @Test
     fun `formatDisplayResult handles out of bounds precision`() = runBlocking {
         // Should clamp value below MIN_PRECISION to MIN_PRECISION
-        assertEquals("0", MathEngine.formatDisplayResult("0.333", Constants.MIN_PRECISION - 1))
+        assertEquals("0", MathEngine.formatDisplayResult("0.333", -2))
         // Should clamp value above MAX_PRECISION to MAX_PRECISION
         assertEquals("0.3330000000", MathEngine.formatDisplayResult("0.333", Constants.MAX_PRECISION + 5))
+    }
+
+    @Test
+    fun `formatDisplayResult shows full precision when precision is off`() = runBlocking {
+        assertEquals("7.1234", MathEngine.formatDisplayResult("7.1234", Constants.PRECISION_OFF))
+        assertEquals("1234.5678", MathEngine.formatDisplayResult("1234.5678", Constants.PRECISION_OFF))
+        assertEquals("0.3333333333333333", MathEngine.formatDisplayResult("0.3333333333333333", Constants.PRECISION_OFF))
+        assertEquals("10.0", MathEngine.formatDisplayResult("10", Constants.PRECISION_OFF))
+        assertEquals("1.0E20", MathEngine.formatDisplayResult("1.0E20", Constants.PRECISION_OFF))
+        assertEquals("5.1234 km", MathEngine.formatDisplayResult("5.1234 km", Constants.PRECISION_OFF))
     }
 
     @Test

--- a/app/src/test/java/com/vishaltelangre/nerdcalci/core/RationalTest.kt
+++ b/app/src/test/java/com/vishaltelangre/nerdcalci/core/RationalTest.kt
@@ -10,7 +10,7 @@ import java.math.BigInteger
 class RationalTest {
 
     @Test
-    fun testSimplification() {
+    fun `simplification reduces fractions to lowest terms`() {
         assertEquals("1/2", Rational(2.toBigInteger(), 4.toBigInteger()).toString())
         assertEquals("1/3", Rational(10.toBigInteger(), 30.toBigInteger()).toString())
         assertEquals("-1/2", Rational((-2).toBigInteger(), 4.toBigInteger()).toString())
@@ -21,7 +21,7 @@ class RationalTest {
     }
 
     @Test
-    fun testAddition() {
+    fun `addition correctly calculates sum of fractions`() {
         val r1 = Rational(1.toBigInteger(), 2.toBigInteger())
         val r2 = Rational(1.toBigInteger(), 3.toBigInteger())
         assertEquals("5/6", (r1 + r2).toString())
@@ -32,28 +32,28 @@ class RationalTest {
     }
 
     @Test
-    fun testSubtraction() {
+    fun `subtraction correctly calculates difference of fractions`() {
         val r1 = Rational(1.toBigInteger(), 2.toBigInteger())
         val r2 = Rational(1.toBigInteger(), 3.toBigInteger())
         assertEquals("1/6", (r1 - r2).toString())
     }
 
     @Test
-    fun testMultiplication() {
+    fun `multiplication correctly calculates product of fractions`() {
         val r1 = Rational(2.toBigInteger(), 3.toBigInteger())
         val r2 = Rational(3.toBigInteger(), 4.toBigInteger())
         assertEquals("1/2", (r1 * r2).toString())
     }
 
     @Test
-    fun testDivision() {
+    fun `division correctly calculates quotient of fractions`() {
         val r1 = Rational(1.toBigInteger(), 2.toBigInteger())
         val r2 = Rational(3.toBigInteger(), 4.toBigInteger())
         assertEquals("2/3", (r1 / r2).toString())
     }
 
     @Test
-    fun testDivisionByZeroThrows() {
+    fun `division by zero throws DivisionByZeroException`() {
         val r1 = Rational(1.toBigInteger(), 2.toBigInteger())
         val zero = Rational.ZERO
 
@@ -66,7 +66,7 @@ class RationalTest {
     }
 
     @Test
-    fun testToRational() {
+    fun `toRational converts simple decimals to exact fractions`() {
         assertEquals("1/2", Rational.toRational(BigDecimal("0.5")).toString())
         assertEquals("1/4", Rational.toRational(BigDecimal("0.25")).toString())
         assertEquals("33/10", Rational.toRational(BigDecimal("3.3")).toString())
@@ -74,13 +74,13 @@ class RationalTest {
     }
 
     @Test
-    fun testToRationalNegativeDecimal() {
+    fun `toRational handles negative decimal values`() {
         assertEquals("-1/2", Rational.toRational(BigDecimal("-0.5")).toString())
         assertEquals("-3/4", Rational.toRational(BigDecimal("-0.75")).toString())
     }
 
     @Test
-    fun testNegateAndIsWhole() {
+    fun `negate and isWhole provide correct rational properties`() {
         val whole = Rational(5.toBigInteger(), 1.toBigInteger())
         val fraction = Rational(3.toBigInteger(), 4.toBigInteger())
 
@@ -91,15 +91,75 @@ class RationalTest {
     }
 
     @Test
-    fun testFromBigDecimalSmart() {
+    fun `fromBigDecimalSmart approximates repeating decimals while respecting limits`() {
         // Simple fractions
         assertEquals("1/3", Rational.fromBigDecimalSmart(BigDecimal("0.3333333333333333")).toString())
         assertEquals("1/7", Rational.fromBigDecimalSmart(BigDecimal("0.14285714285714285")).toString())
         
-        // Very small non-zero values (should not collapse to 0)
+        // Very small non-zero values (within limits)
         assertEquals("1/100000000000000000", Rational.fromBigDecimalSmart(BigDecimal("1e-17")).toString())
+        
+        // Extreme scientific notation (should return null due to complexity limits)
+        assertTrue(Rational.fromBigDecimalSmart(BigDecimal("1.0E-10000")) == null)
         
         // Zero should still be zero
         assertEquals("0", Rational.fromBigDecimalSmart(BigDecimal.ZERO).toString())
+    }
+
+    @Test
+    fun `toRational enforces exact exponent limits for conversions`() {
+        // Within limits
+        val withinLimit = BigDecimal("1.0").movePointLeft(1000)
+        assertTrue(Rational.toRational(withinLimit) != null)
+
+        // Beyond exact exponent limit (MAX_EXACT_EXPONENT = 10000)
+        val beyondLimit = BigDecimal("1.0").movePointLeft(10001)
+        assertTrue(Rational.toRational(beyondLimit) == null)
+    }
+
+    @Test
+    fun `arithmetic operations throw exception if result exceeds complexity limits`() {
+        // Create a large rational near the bit limit (16000 bits)
+        val largeNum = BigInteger.valueOf(2).pow(15000)
+        val r1 = Rational(largeNum, BigInteger.ONE)
+        
+        // r1 * r1 should exceed 16000 bits
+        try {
+            r1 * r1
+            throw AssertionError("Expected ArithmeticException for too complex rational")
+        } catch (_: ArithmeticException) {
+            // Expected
+        }
+    }
+
+    @Test
+    fun `equality and hashcode handle simplified fractions correctly`() {
+        val r1 = Rational(BigInteger.valueOf(1), BigInteger.valueOf(2))
+        val r2 = Rational(BigInteger.valueOf(2), BigInteger.valueOf(4)) // Simplifies to 1/2
+        val r3 = Rational(BigInteger.valueOf(1), BigInteger.valueOf(3))
+        
+        assertTrue(r1 == r2)
+        assertEquals(r1.hashCode(), r2.hashCode())
+        assertFalse(r1 == r3)
+    }
+
+    @Test
+    fun `toLongOrNull validates integral values within long range`() {
+        assertEquals(123L, Rational.fromLong(123).toLongOrNull())
+        assertEquals(null, Rational(BigInteger.ONE, BigInteger.valueOf(2)).toLongOrNull())
+        
+        // Too large for Long
+        val large = BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE)
+        assertEquals(null, Rational(large, BigInteger.ONE).toLongOrNull())
+    }
+
+    @Test
+    fun `compareTo provides correct ordering for rational fractions`() {
+        val r1 = Rational(BigInteger.valueOf(1), BigInteger.valueOf(2))
+        val r2 = Rational(BigInteger.valueOf(1), BigInteger.valueOf(3))
+        
+        assertTrue(r1 > r2)
+        assertTrue(r2 < r1)
+        assertTrue(r1.compareTo(Rational(BigInteger.valueOf(2), BigInteger.valueOf(4))) == 0)
     }
 }

--- a/fastlane/metadata/android/en-US/changelogs/386.txt
+++ b/fastlane/metadata/android/en-US/changelogs/386.txt
@@ -1,0 +1,3 @@
+- Added a toggle to turn off "Result precision" and see full unrounded results (Issue #134).
+- Fixed a bug that could cause the app to hang when toggling Rational Mode on certain scientific notation inputs.
+- Fixed the result precision ellipsis (`…`) styling for results with units (e.g., `(1/3) km`).


### PR DESCRIPTION
- Fixes #134.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a toggle to disable "Result precision" (shows full unrounded results). When enabled, a separate "Decimal places" slider appears; when disabled, precision-related preview and ellipsis controls are hidden.

* **Bug Fixes**
  * Fixed an app hang when enabling Rational Mode for certain scientific-notation inputs.
  * Corrected precision ellipsis styling for results that include units.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->