### PR TITLE
Fix date related issues and a bug with `<variable>%` syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.1] - 2026-05-03
+### Added
+- Added support for regional date format preferences (DD/MM/YYYY, MM/DD/YYYY, YYYY/MM/DD) for numeric inputs (Issue #162).
+
+### Fixed
+- Fixed an off-by-one error in date intervals when the time component made the final day incomplete (Issue #163).
+- Fixed a bug where variable percentages (e.g., `a% of b`) resulted in an error.
+
 ## [4.0.0] - 2026-05-02
 ### Added
 - Added a powerful, calendar-aware date engine for complex arithmetic and natural language queries (e.g., `today + 3 weeks`).

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -933,8 +933,11 @@ Dates are constructed using specific functions to avoid ambiguity with numeric e
 - `"April 1, 2019"` (US style) → returns a date
 - `"1 April 2019"` (International style) → returns a date
 - `"June 10"` (Infers the closest year) → returns a date
-- `"YYYY-MM-DD"` (ISO 8601 date) → returns a date
-- `"YYYY/MM/DD"` (slash-delimited date, not strict ISO 8601) → returns a date
+- **Regional numeric formats** (configurable in Settings):
+  - `"DD/MM/YYYY"` (e.g. `10/05/2024`)
+  - `"MM/DD/YYYY"` (e.g. `05/10/2024`)
+  - `"YYYY/MM/DD"` (e.g. `2024/05/10`)
+  - **Note**: A 4-digit year (`YYYY`) is required for these numeric formats to prevent ambiguity. Separators like `/`, `-`, and `.` are supported interchangeably.
 - `"YYYY-MM-DDTHH:MM:SS+HH:MM"` (ISO 8601 with time and offset) → returns a date-time
 - Unix epoch timestamp (e.g. `1714636800`) → returns a **date-time** (system timezone)
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
     defaultConfig {
         applicationId = "com.vishaltelangre.nerdcalci"
         minSdk = 23
-        versionCode = 400
-        versionName = "4.0.0"
+        versionCode = 401
+        versionName = "4.0.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/Ast.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/Ast.kt
@@ -36,13 +36,13 @@ sealed class Expr {
     data class NumberLiteral(val value: BigDecimal) : Expr()
 
     /** Percentage literal: `20%` — a bare percentage without `of`/`off` context. */
-    data class PercentLiteral(val value: BigDecimal) : Expr()
+    data class PercentLiteral(val value: Expr) : Expr()
 
     /** Percentage-of: `20% of price` → `price * 0.20` */
-    data class PercentOf(val percent: BigDecimal, val base: Expr) : Expr()
+    data class PercentOf(val percent: Expr, val base: Expr) : Expr()
 
     /** Percentage-off: `15% off price` → `price * (1 - 0.15)` */
-    data class PercentOff(val percent: BigDecimal, val base: Expr) : Expr()
+    data class PercentOff(val percent: Expr, val base: Expr) : Expr()
 
     /** Unary negation: `-expr` */
     data class UnaryMinus(val operand: Expr) : Expr()

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/Builtins.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/Builtins.kt
@@ -300,9 +300,9 @@ object Builtins {
         return fn.body(args)
     }
 
-    fun execute(name: String, args: List<EvaluationResult>, variables: Map<String, EvaluationResult>): EvaluationResult {
+    fun execute(name: String, args: List<EvaluationResult>, variables: Map<String, EvaluationResult>, dateFormat: String = Constants.DATE_FORMAT_DMY): EvaluationResult {
         when (name) {
-            "parseDate" -> return executeParseDate(args)
+            "parseDate" -> return executeParseDate(args, dateFormat)
             "date" -> return executeDate(args)
             "datetime" -> return executeDateTime(args)
             "datetimeZ" -> return executeDateTimeZ(args)
@@ -321,11 +321,11 @@ object Builtins {
         return fn.unitPolicy.evaluate(normalizedArgs, fn.body, variables)
     }
 
-    private fun executeParseDate(args: List<EvaluationResult>): EvaluationResult {
+    private fun executeParseDate(args: List<EvaluationResult>, dateFormat: String): EvaluationResult {
         if (args.size != 1) throw ArityMismatchException("parseDate", 1, args.size)
         val arg = args[0]
         return when {
-            arg.stringResult != null -> EvaluationResult(value = null, dateTimeResult = DateStringParser.parse(arg.stringResult))
+            arg.stringResult != null -> EvaluationResult(value = null, dateTimeResult = DateStringParser.parse(arg.stringResult, dateFormat))
             arg.value != null -> EvaluationResult(value = null, dateTimeResult = DateStringParser.parseEpoch(arg.value.toLong()))
             else -> throw EvalException("`parseDate()` expects a numeric epoch or a date string")
         }

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/Constants.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/Constants.kt
@@ -57,12 +57,20 @@ object Constants {
     // Temporary scratchpad settings
     const val PREF_AUTO_OPEN_SCRATCHPAD = "auto_open_scratchpad" // @deprecated
     const val PREF_SHOW_SCRATCHPAD = "show_scratchpad"
+
     const val PREF_LAUNCH_MODE = "launch_mode"
     const val PREF_LAUNCH_FILE_ID = "launch_file_id"
     const val PREF_SHOW_PRECISION_ELLIPSIS = "show_precision_ellipsis"
     const val PREF_FILE_SORT_CRITERIA = "file_sort_criteria"
     const val PREF_COLOR_PALETTE = "color_palette"
     const val SCRATCHPAD_DISPLAY_NAME = "Scratchpad"
+
+    // Date format settings
+    const val PREF_DATE_FORMAT = "date_format"
+    const val DATE_FORMAT_AUTO = "auto"
+    const val DATE_FORMAT_DMY = "dd_mm_yyyy"
+    const val DATE_FORMAT_MDY = "mm_dd_yyyy"
+    const val DATE_FORMAT_YMD = "yyyy_mm_dd"
 
     // Editor font size settings
     const val PREF_EDITOR_FONT_SIZE = "editor_font_size"

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/DateEvaluator.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/DateEvaluator.kt
@@ -155,24 +155,14 @@ object DateEvaluator {
 
         if (hasDateTime) {
             // Preserve full instant precision so datetime-to-datetime intervals include time.
-            val fromZdt: ZonedDateTime = when (from) {
-                is DateTimeResult.DateTime -> from.instant
-                is DateTimeResult.Date     -> from.date.atStartOfDay(systemZone)
-                else -> throw EvalException("Expected a date or datetime operand.")
-            }
-            val rawToZdt: ZonedDateTime = when (to) {
-                is DateTimeResult.DateTime -> to.instant
-                is DateTimeResult.Date     -> to.date.atStartOfDay(systemZone)
-                else -> throw EvalException("Expected a date or datetime operand.")
-            }
+            val fromZdt = toZonedDateTime(from)
+            val rawToZdt = toZonedDateTime(to)
             // Apply inclusive (+1 day) only if the end operand was a plain date.
             val toZdt = if (inclusive && to is DateTimeResult.Date) rawToZdt.plusDays(1) else rawToZdt
 
             val isBackward = fromZdt.isAfter(toZdt)
             val (startZdt, endZdt) = if (isBackward) toZdt to fromZdt else fromZdt to toZdt
 
-            // Use java.time.Duration for the sub-day part and Period for the calendar part.
-            val period = Period.between(startZdt.toLocalDate(), endZdt.toLocalDate())
             val startOfEndDate = endZdt.toLocalDate().atStartOfDay(endZdt.zone)
             val timeDuration = java.time.Duration.between(startOfEndDate, endZdt)
             val extraSeconds = timeDuration.seconds  // seconds into the end day
@@ -185,10 +175,18 @@ object DateEvaluator {
 
             var totalDays = ChronoUnit.DAYS.between(startZdt.toLocalDate(), endZdt.toLocalDate())
             var remainingSeconds = netSeconds
-            if (remainingSeconds < 0) {
+
+            // Adjust the calendar boundary if the time part makes the last day incomplete.
+            val adjustedEndDate = if (remainingSeconds < 0) {
                 totalDays--
                 remainingSeconds += 86400L
+                endZdt.toLocalDate().minusDays(1)
+            } else {
+                endZdt.toLocalDate()
             }
+
+            // Recalculate the period based on the adjusted date boundary.
+            val period = Period.between(startZdt.toLocalDate(), adjustedEndDate)
 
             val hours   = remainingSeconds / 3600L
             val minutes = (remainingSeconds % 3600L) / 60L
@@ -380,6 +378,12 @@ object DateEvaluator {
     private fun toLocalDate(dt: DateTimeResult): LocalDate = when (dt) {
         is DateTimeResult.Date     -> dt.date
         is DateTimeResult.DateTime -> dt.instant.toLocalDate()
+        else -> throw EvalException("Expected a date or datetime operand.")
+    }
+
+    private fun toZonedDateTime(dt: DateTimeResult): ZonedDateTime = when (dt) {
+        is DateTimeResult.DateTime -> dt.instant
+        is DateTimeResult.Date     -> dt.date.atStartOfDay(systemZone)
         else -> throw EvalException("Expected a date or datetime operand.")
     }
 }

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/DateStringParser.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/DateStringParser.kt
@@ -9,13 +9,14 @@ import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeParseException
 import java.util.Locale
+import com.vishaltelangre.nerdcalci.utils.RegionUtils
 
 object DateStringParser {
 
     private val systemZone: ZoneId get() = ZoneId.systemDefault()
 
     /**
-     * Parses a string into a DateTimeResult.Date using only unambiguous formats.
+     * Parses a string into a DateTimeResult.Date.
      * Month names are case-insensitive.
      *
      * Accepted formats:
@@ -25,21 +26,17 @@ object DateStringParser {
      *   "1 April 2019"     → full day-month-year
      *   "2019-04-01"       → ISO 8601
      *   "2019/04/01"       → YYYY/MM/DD
-     *
-     * Rejected formats (throw EvalException):
-     *   "12/02/1988"       → ambiguous (DD/MM or MM/DD?)
-     *   "01.05.2005"       → ambiguous
+     *   "10/05/2024"       → Numeric format based on [dateFormat] setting
      *
      * @throws EvalException with actionable message on parse failure.
      */
-    fun parse(input: String): DateTimeResult {
+    fun parse(input: String, dateFormat: String = Constants.DATE_FORMAT_AUTO): DateTimeResult {
         val s = input.trim()
 
-        // Reject ambiguous numeric-only formats explicitly before trying anything else
-        if (s.matches(Regex("""\d{1,2}[/\.]\d{1,2}[/\.]\d{2,4}"""))) {
-            throw EvalException(
-                "Ambiguous date format \"$s\". Use a named month (e.g. \"April 1, 2019\") or ISO 8601 (e.g. \"2019-04-01\") instead."
-            )
+        val resolvedFormat = if (dateFormat == Constants.DATE_FORMAT_AUTO) {
+            RegionUtils.getDefaultDateFormat(Locale.getDefault())
+        } else {
+            dateFormat
         }
 
         // ISO 8601 (or similar): YYYY-MM-DD or YYYY/MM/DD, optionally with T and time and offset
@@ -49,7 +46,7 @@ object DateStringParser {
             val timePart = m.groupValues[2]
             val offsetPart = m.groupValues[3]
             
-        return try {
+            return try {
                 val date = LocalDate.parse(datePart, DateTimeFormatter.ISO_LOCAL_DATE)
                 if (timePart.isEmpty()) {
                     if (offsetPart.isEmpty()) {
@@ -71,6 +68,45 @@ object DateStringParser {
                 }
             } catch (e: java.time.DateTimeException) {
                 throw EvalException("Invalid date/time \"$s\": ${e.message}")
+            }
+        }
+
+        // Numeric-only formats (e.g. 10/05/2024, 2024-10-05, 10.05.2024)
+        // We support /, -, and . as separators. Year must be 4 digits.
+        val numericPattern = Regex("""^(\d{1,4})[/\.-](\d{1,2})[/\.-](\d{1,4})$""")
+        numericPattern.matchEntire(s)?.let { m ->
+            val p1 = m.groupValues[1]
+            val p2 = m.groupValues[2]
+            val p3 = m.groupValues[3]
+
+            val formatHint = when (resolvedFormat) {
+                Constants.DATE_FORMAT_DMY -> "DD/MM/YYYY"
+                Constants.DATE_FORMAT_MDY -> "MM/DD/YYYY"
+                Constants.DATE_FORMAT_YMD -> "YYYY/MM/DD"
+                else -> ""
+            }
+
+            try {
+                return when (resolvedFormat) {
+                    Constants.DATE_FORMAT_DMY -> {
+                        if (p3.length != 4) throw EvalException("Year must be 4 digits in numeric date \"$s\" (expected $formatHint).")
+                        buildDate(p3.toInt(), p2.toInt(), p1.toInt(), s)
+                    }
+                    Constants.DATE_FORMAT_MDY -> {
+                        if (p3.length != 4) throw EvalException("Year must be 4 digits in numeric date \"$s\" (expected $formatHint).")
+                        buildDate(p3.toInt(), p1.toInt(), p2.toInt(), s)
+                    }
+                    Constants.DATE_FORMAT_YMD -> {
+                        if (p1.length != 4) throw EvalException("Year must be 4 digits in numeric date \"$s\" (expected $formatHint).")
+                        buildDate(p1.toInt(), p2.toInt(), p3.toInt(), s)
+                    }
+                    else -> throw EvalException("Unknown date format setting.")
+                }
+            } catch (e: EvalException) {
+                if (formatHint.isNotEmpty() && e.message?.contains("expected") == false) {
+                    throw EvalException("${e.message} (expected $formatHint)")
+                }
+                throw e
             }
         }
 

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/Evaluator.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/Evaluator.kt
@@ -131,30 +131,38 @@ class Evaluator(
         }
         is Expr.NumberLiteral  -> EvaluationResult(expr.value, rationalValue = Rational.toRational(expr.value))
         is Expr.PercentLiteral -> {
-            val res = expr.value.divide(BigDecimal("100"), mc)
+            val eval = evaluate(expr.value)
+            val value = eval.value ?: throw EvalException("Cannot apply percentage to a non-numeric value")
+            val res = value.divide(BigDecimal("100"), mc)
             EvaluationResult(res, rationalValue = Rational.toRational(res))
         }
         is Expr.PercentOf      -> {
+            val pctEval = evaluate(expr.percent)
+            val pct = pctEval.value ?: throw EvalException("Cannot apply percentage to a non-numeric value")
+
             val baseEval = evaluate(expr.base)
             val base = baseEval.value ?: throw EvalException("Cannot apply percentage to a non-numeric value")
             val baseUnit = baseEval.unit?.let { UnitConverter.findUnit(it) }
             val resultUnit = if (baseUnit != null && baseUnit.category != UnitCategory.SCALAR) baseEval.unit else null
-            val resultValue = base.multiply(expr.percent).divide(BigDecimal("100"), mc)
+            val resultValue = base.multiply(pct).divide(BigDecimal("100"), mc)
 
             val baseRational = baseEval.rationalValue ?: Rational.toRational(base)
-            val percentRational = Rational.toRational(expr.percent.divide(BigDecimal("100"), mc))
+            val percentRational = Rational.toRational(pct.divide(BigDecimal("100"), mc))
             EvaluationResult(resultValue, resultUnit, rationalValue = applyRationalOp(baseRational, TokenKind.STAR, percentRational))
         }
         is Expr.PercentOff     -> {
+            val pctEval = evaluate(expr.percent)
+            val pct = pctEval.value ?: throw EvalException("Cannot apply percentage to a non-numeric value")
+
             val baseEval = evaluate(expr.base)
             val base = baseEval.value ?: throw EvalException("Cannot apply percentage to a non-numeric value")
             val baseUnit = baseEval.unit?.let { UnitConverter.findUnit(it) }
             val resultUnit = if (baseUnit != null && baseUnit.category != UnitCategory.SCALAR) baseEval.unit else null
-            val factor = BigDecimal.ONE.subtract(expr.percent.divide(BigDecimal("100"), mc))
+            val factor = BigDecimal.ONE.subtract(pct.divide(BigDecimal("100"), mc))
             val resultValue = base.multiply(factor)
 
             val baseRational = baseEval.rationalValue ?: Rational.toRational(base)
-            val factorRational = applyRationalOp(Rational.ONE, TokenKind.MINUS, Rational.toRational(expr.percent.divide(BigDecimal("100"), mc)))
+            val factorRational = applyRationalOp(Rational.ONE, TokenKind.MINUS, Rational.toRational(pct.divide(BigDecimal("100"), mc)))
             EvaluationResult(resultValue, resultUnit, rationalValue = applyRationalOp(baseRational, TokenKind.STAR, factorRational))
         }
         is Expr.UnaryMinus     -> {
@@ -665,7 +673,8 @@ class Evaluator(
 
         // Percentage addition/subtraction
         if (expr.right is Expr.PercentLiteral) {
-            val pct = expr.right.value
+            val pctEval = evaluate((expr.right as Expr.PercentLiteral).value)
+            val pct = pctEval.value ?: throw EvalException("Cannot apply percentage to a non-numeric value")
             val leftVal = leftEval.value ?: BigDecimal.ZERO
             val leftRational = leftEval.rationalValue ?: Rational.toRational(leftVal)
             val pctRational = Rational.toRational(pct.divide(BigDecimal("100"), mc))

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/Evaluator.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/Evaluator.kt
@@ -132,13 +132,15 @@ class Evaluator(
         is Expr.NumberLiteral  -> EvaluationResult(expr.value, rationalValue = Rational.toRational(expr.value))
         is Expr.PercentLiteral -> {
             val eval = evaluate(expr.value)
-            val value = eval.value ?: throw EvalException("Cannot apply percentage to a non-numeric value")
+            if (!isUnitlessScalar(eval)) throw EvalException("Cannot apply percentage to a non-numeric value")
+            val value = eval.value!!
             val res = value.divide(BigDecimal("100"), mc)
             EvaluationResult(res, rationalValue = Rational.toRational(res))
         }
         is Expr.PercentOf      -> {
             val pctEval = evaluate(expr.percent)
-            val pct = pctEval.value ?: throw EvalException("Cannot apply percentage to a non-numeric value")
+            if (!isUnitlessScalar(pctEval)) throw EvalException("Cannot apply percentage to a non-numeric value")
+            val pct = pctEval.value!!
 
             val baseEval = evaluate(expr.base)
             val base = baseEval.value ?: throw EvalException("Cannot apply percentage to a non-numeric value")
@@ -152,7 +154,8 @@ class Evaluator(
         }
         is Expr.PercentOff     -> {
             val pctEval = evaluate(expr.percent)
-            val pct = pctEval.value ?: throw EvalException("Cannot apply percentage to a non-numeric value")
+            if (!isUnitlessScalar(pctEval)) throw EvalException("Cannot apply percentage to a non-numeric value")
+            val pct = pctEval.value!!
 
             val baseEval = evaluate(expr.base)
             val base = baseEval.value ?: throw EvalException("Cannot apply percentage to a non-numeric value")
@@ -674,7 +677,8 @@ class Evaluator(
         // Percentage addition/subtraction
         if (expr.right is Expr.PercentLiteral) {
             val pctEval = evaluate((expr.right as Expr.PercentLiteral).value)
-            val pct = pctEval.value ?: throw EvalException("Cannot apply percentage to a non-numeric value")
+            if (!isUnitlessScalar(pctEval)) throw EvalException("Cannot apply percentage to a non-numeric value")
+            val pct = pctEval.value!!
             val leftVal = leftEval.value ?: BigDecimal.ZERO
             val leftRational = leftEval.rationalValue ?: Rational.toRational(leftVal)
             val pctRational = Rational.toRational(pct.divide(BigDecimal("100"), mc))
@@ -1090,7 +1094,8 @@ class Evaluator(
             fileVariables = remoteContext.fileVariables,
             fileContextLoader = fileContextLoader,
             loadingStack = loadingStack + fileName,
-            rationalMode = rationalMode
+            rationalMode = rationalMode,
+            dateFormat = dateFormat
         )
         return remoteEvaluator.evaluateFunction(name, evaluatedArgs)
     }
@@ -1110,6 +1115,13 @@ class Evaluator(
         } else {
             throw EvalException("You can only $operation other files using dot notation")
         }
+    }
+
+    private fun isUnitlessScalar(eval: EvaluationResult): Boolean {
+        if (eval.value == null) return false
+        if (eval.unit == null) return true
+        val unit = UnitConverter.findUnit(eval.unit)
+        return unit?.category == UnitCategory.SCALAR
     }
 
     private fun isPhysicalUnit(unit: NerdUnit?): Boolean {

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/Evaluator.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/Evaluator.kt
@@ -37,7 +37,8 @@ class Evaluator(
     private val fileVariables: Map<String, String> = emptyMap(),
     private val fileContextLoader: FileContextLoader? = null,
     private val loadingStack: Set<String> = emptySet(),
-    private val rationalMode: Boolean = false
+    private val rationalMode: Boolean = false,
+    private val dateFormat: String = Constants.DATE_FORMAT_AUTO
 ) {
     private val mc = JavaMathContext.DECIMAL128
 
@@ -295,7 +296,8 @@ class Evaluator(
                 fileVariables = fileVariables,
                 fileContextLoader = fileContextLoader,
                 loadingStack = loadingStack,
-                rationalMode = rationalMode
+                rationalMode = rationalMode,
+                dateFormat = dateFormat
             )
             val localContext = MathContext(variables = localVars)
             var lastResult: EvaluationResult? = null
@@ -341,7 +343,7 @@ class Evaluator(
         }
 
         val evaluatedArgs = argExprs.map { evaluate(it) }
-        return Builtins.execute(name, evaluatedArgs, variables)
+        return Builtins.execute(name, evaluatedArgs, variables, dateFormat)
     }
 
     /**

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/MathEngine.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/MathEngine.kt
@@ -23,7 +23,8 @@ data class MathContext(
     val userAssignedDynamicVariables: MutableSet<String> = mutableSetOf(),
     val fileVariables: MutableMap<String, String> = mutableMapOf(), // varName -> fileName
     val injectionErrors: MutableMap<String, Exception> = mutableMapOf(),
-    val rationalMode: Boolean = false
+    val rationalMode: Boolean = false,
+    val dateFormat: String = Constants.DATE_FORMAT_DMY
 )
 
 object MathEngine {
@@ -114,8 +115,8 @@ object MathEngine {
      * @param lines List of line entities to calculate
      * @return List of line entities with populated results
      */
-    suspend fun calculate(lines: List<LineEntity>, loader: FileContextLoader? = null, rationalMode: Boolean = false): List<LineEntity> {
-        return calculateWithContext(lines, MathContext(rationalMode = rationalMode), loader)
+    suspend fun calculate(lines: List<LineEntity>, loader: FileContextLoader? = null, rationalMode: Boolean = false, dateFormat: String = Constants.DATE_FORMAT_AUTO): List<LineEntity> {
+        return calculateWithContext(lines, MathContext(rationalMode = rationalMode, dateFormat = dateFormat), loader)
     }
 
     /**
@@ -128,9 +129,10 @@ object MathEngine {
         lines: List<LineEntity>,
         loader: FileContextLoader? = null,
         loadingStack: Set<String> = emptySet(),
-        rationalMode: Boolean = false
+        rationalMode: Boolean = false,
+        dateFormat: String = Constants.DATE_FORMAT_AUTO
     ): MathContext {
-        val context = MathContext(rationalMode = rationalMode)
+        val context = MathContext(rationalMode = rationalMode, dateFormat = dateFormat)
         for (line in lines) {
             if (line.expression.isBlank()) {
                 context.lineResults.add(null)
@@ -162,7 +164,7 @@ object MathEngine {
      * @param changedIndex  Index of the first line that changed (0-based).
      * @return Recalculated affected lines: `allLines[changedIndex..end]` with updated results.
      */
-    suspend fun calculateFrom(allLines: List<LineEntity>, changedIndex: Int, loader: FileContextLoader? = null, loadingStack: Set<String> = emptySet(), rationalMode: Boolean = false): List<LineEntity> {
+    suspend fun calculateFrom(allLines: List<LineEntity>, changedIndex: Int, loader: FileContextLoader? = null, loadingStack: Set<String> = emptySet(), rationalMode: Boolean = false, dateFormat: String = Constants.DATE_FORMAT_AUTO): List<LineEntity> {
         // Determine which lines are affected by the edit
         val firstAffectedIndex = changedIndex.coerceIn(0, allLines.size)
         val precedingLines = allLines.subList(0, firstAffectedIndex)
@@ -171,10 +173,10 @@ object MathEngine {
         try {
             // Collect variable state and line results from preceding lines,
             // then fully recalculate affected lines
-            val context = buildVariableState(precedingLines, loader, loadingStack, rationalMode)
+            val context = buildVariableState(precedingLines, loader, loadingStack, rationalMode, dateFormat)
             return calculateWithContext(affectedLines, context, loader, loadingStack)
         } catch (e: CircularReferenceException) {
-            return calculateWithContext(allLines, MathContext(rationalMode = rationalMode), loader, loadingStack)
+            return calculateWithContext(allLines, MathContext(rationalMode = rationalMode, dateFormat = dateFormat), loader, loadingStack)
         }
     }
 
@@ -182,14 +184,14 @@ object MathEngine {
      * Re-evaluates a specific line to capture the exact exception message.
      * Used for on-demand error tooltips.
      */
-    suspend fun getErrorDetails(allLines: List<LineEntity>, targetIndex: Int, loader: FileContextLoader? = null, loadingStack: Set<String> = emptySet(), rationalMode: Boolean = false): String? {
+    suspend fun getErrorDetails(allLines: List<LineEntity>, targetIndex: Int, loader: FileContextLoader? = null, loadingStack: Set<String> = emptySet(), rationalMode: Boolean = false, dateFormat: String = Constants.DATE_FORMAT_AUTO): String? {
         if (targetIndex < 0 || targetIndex >= allLines.size) return null
 
         val precedingLines = allLines.subList(0, targetIndex)
         val targetLine = allLines[targetIndex]
 
         try {
-            val context = buildVariableState(precedingLines, loader, loadingStack, rationalMode)
+            val context = buildVariableState(precedingLines, loader, loadingStack, rationalMode, dateFormat)
             injectDynamicVariables(context)
             evaluateLine(targetLine.expression, context, loader, loadingStack)
             return null // No error occurred during this evaluation
@@ -216,7 +218,7 @@ object MathEngine {
         val lineResults = context.lineResults
         val userAssignedDynamicVariables = context.userAssignedDynamicVariables.toMutableSet()
         val fileVariables = context.fileVariables.toMutableMap()
-        val isolatedContext = MathContext(variables, localFunctions, lineResults, userAssignedDynamicVariables, fileVariables, rationalMode = context.rationalMode)
+        val isolatedContext = MathContext(variables, localFunctions, lineResults, userAssignedDynamicVariables, fileVariables, rationalMode = context.rationalMode, dateFormat = context.dateFormat)
 
         return lines.map { line ->
             if (line.expression.isBlank()) {
@@ -511,7 +513,8 @@ object MathEngine {
             fileVariables = context.fileVariables,
             fileContextLoader = loader,
             loadingStack = loadingStack,
-            rationalMode = context.rationalMode
+            rationalMode = context.rationalMode,
+            dateFormat = context.dateFormat
         ).evaluateStatement(statement, context)
     }
 

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/Parser.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/Parser.kt
@@ -391,31 +391,58 @@ class Parser(private val tokens: List<Token>) {
      */
     private fun parsePostfix(): Expr {
         var expr = parsePrimary()
-        // Continue consuming as long as next token is a DOT
-        while (peekKind() == TokenKind.DOT) {
-            advance() // consume "."
-            val token = peek()
+        while (true) {
+            val kind = peekKind()
+            if (kind == TokenKind.DOT) {
+                advance() // consume "."
+                val token = peek()
 
-            if (token.kind != TokenKind.IDENTIFIER && !token.kind.name.startsWith("KW_")) {
-                val message = if (token.kind == TokenKind.EOF) {
-                    "Missing variable or function name after `.`"
-                } else {
-                    "Expected variable or function name after `.`, but found `${token.lexeme}`"
+                if (token.kind != TokenKind.IDENTIFIER && !token.kind.name.startsWith("KW_")) {
+                    val message = if (token.kind == TokenKind.EOF) {
+                        "Missing variable or function name after `.`"
+                    } else {
+                        "Expected variable or function name after `.`, but found `${token.lexeme}`"
+                    }
+                    throw ParseException(message, token.position)
                 }
-                throw ParseException(message, token.position)
-            }
-            advance()
-            val name = token.lexeme
+                advance()
+                val name = token.lexeme
 
-            // Check if it's a member function call
-            if (peekKind() == TokenKind.LPAREN) {
-                advance() // consume "("
-                val args = parseArgList()
-                expect(TokenKind.RPAREN)
-                expr = Expr.MemberFunctionCall(expr, name, args)
+                // Check if it's a member function call
+                if (peekKind() == TokenKind.LPAREN) {
+                    advance() // consume "("
+                    val args = parseArgList()
+                    expect(TokenKind.RPAREN)
+                    expr = Expr.MemberFunctionCall(expr, name, args)
+                } else {
+                    // Otherwise treat it as a property/variable accessor
+                    expr = Expr.MemberAccess(expr, name)
+                }
+            } else if (kind == TokenKind.PERCENT) {
+                val nextKind = peekAt(1)
+                // e.g. a% of b
+                if (nextKind == TokenKind.KW_OF) {
+                    advance() // skip past "%"
+                    advance() // skip past "of"
+                    val base = parseExpression()
+                    expr = Expr.PercentOf(expr, base)
+                // e.g. a% off b
+                } else if (nextKind == TokenKind.KW_OFF) {
+                    advance() // skip past "%"
+                    advance() // skip past "off"
+                    val base = parseExpression()
+                    expr = Expr.PercentOff(expr, base)
+                } else if (canStartExpression(nextKind)) {
+                    // % is followed by expression, so it's a MODULO operator.
+                    // Do not consume % here; let parseMulDivMod handle it.
+                    break
+                // e.g. bare a% (used in "price + a%")
+                } else {
+                    advance() // skip past "%"
+                    expr = Expr.PercentLiteral(expr)
+                }
             } else {
-                // Otherwise treat it as a property/variable accessor
-                expr = Expr.MemberAccess(expr, name)
+                break
             }
         }
         return expr
@@ -463,31 +490,6 @@ class Parser(private val tokens: List<Token>) {
                     if (multiplier != null) {
                         advance() // consume numeral word
                         numericValue *= multiplier
-                    }
-                }
-
-                // Check for percentage syntax: 20% of X, 15% off X, or bare 20%
-                if (peekKind() == TokenKind.PERCENT) {
-                    val nextKind = peekAt(1)
-                    // e.g. 20% of price
-                    if (nextKind == TokenKind.KW_OF) {
-                        advance() // skip past "%"
-                        advance() // skip past "of"
-                        val base = parseExpression()
-                        return Expr.PercentOf(numericValue, base)
-                    // e.g. 15% off price
-                    } else if (nextKind == TokenKind.KW_OFF) {
-                        advance() // skip past "%"
-                        advance() // skip past "off"
-                        val base = parseExpression()
-                        return Expr.PercentOff(numericValue, base)
-                    } else if (canStartExpression(nextKind)) {
-                        // % is followed by expression, so it's a MODULO operator.
-                        // Do not consume % here; let parseMulDivMod handle it.
-                    // e.g. bare 20% (used in "price + 20%")
-                    } else {
-                        advance() // skip past "%"
-                        return Expr.PercentLiteral(numericValue)
                     }
                 }
 

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/MainActivity.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/MainActivity.kt
@@ -407,6 +407,7 @@ fun CalculatorNavHost(viewModel: CalculatorViewModel, navController: NavHostCont
             val groupingSeparatorEnabled by viewModel.groupingSeparatorEnabled.collectAsState()
             val showPrecisionEllipsis by viewModel.showPrecisionEllipsis.collectAsState()
             val editorFontSize by viewModel.editorFontSize.collectAsState()
+            val dateFormat by viewModel.dateFormat.collectAsState()
 
             CalculatorSettingsScreen(
                 precision = precision,
@@ -414,13 +415,15 @@ fun CalculatorNavHost(viewModel: CalculatorViewModel, navController: NavHostCont
                 rationalMode = rationalMode,
                 onRationalModeChange = { viewModel.setRationalMode(it) },
                 regionCode = regionCode,
-                onRegionCodeChange = { viewModel.setRegionCode(it) },
+                onRegionCodeChange = { viewModel.setRegionCode(it, viewModel.currentFileId.value) },
                 groupingSeparatorEnabled = groupingSeparatorEnabled,
                 onGroupingSeparatorEnabledChange = { viewModel.setGroupingSeparatorEnabled(it) },
                 showPrecisionEllipsis = showPrecisionEllipsis,
                 onShowPrecisionEllipsisChange = { viewModel.setShowPrecisionEllipsis(it) },
                 editorFontSize = editorFontSize,
                 onEditorFontSizeChange = { viewModel.setEditorFontSize(it) },
+                dateFormat = dateFormat,
+                onDateFormatChange = { viewModel.setDateFormat(it, viewModel.currentFileId.value) },
                 showLineNumbers = showLineNumbers,
                 onShowLineNumbersChange = { viewModel.setShowLineNumbers(it) },
                 showSuggestions = showSuggestions,

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorScreen.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorScreen.kt
@@ -91,6 +91,7 @@ import androidx.compose.foundation.border
 import android.widget.Toast
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -529,7 +530,14 @@ fun CalculatorScreen(
     val canRedo = canRedoMap[fileId] ?: false
 
     LaunchedEffect(fileId, effectiveRationalMode) {
+        viewModel.setCurrentFileId(fileId)
         viewModel.recalculateFile(fileId, effectiveRationalMode)
+    }
+
+    DisposableEffect(fileId) {
+        onDispose {
+            viewModel.setCurrentFileId(null)
+        }
     }
 
     val lines by viewModel.getLines(fileId).collectAsState(initial = emptyList())

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorScreen.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorScreen.kt
@@ -536,7 +536,9 @@ fun CalculatorScreen(
 
     DisposableEffect(fileId) {
         onDispose {
-            viewModel.setCurrentFileId(null)
+            if (viewModel.currentFileId.value == fileId) {
+                viewModel.setCurrentFileId(null)
+            }
         }
     }
 

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorViewModel.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorViewModel.kt
@@ -283,7 +283,7 @@ class CalculatorViewModel(
         _restoreProgress.value = RestoreProgressState()
     }
 
-    private fun createFileContextLoader(currentFileId: Long, rationalMode: Boolean = false, dateFormat: String = Constants.DATE_FORMAT_DMY): FileContextLoader {
+    private fun createFileContextLoader(currentFileId: Long, rationalMode: Boolean = false, dateFormat: String = Constants.DATE_FORMAT_AUTO): FileContextLoader {
         val cache = mutableMapOf<String, MathContext>()
         return object : FileContextLoader {
             override suspend fun loadContext(fileName: String, loadingStack: Set<String>): MathContext? {
@@ -870,7 +870,13 @@ class CalculatorViewModel(
         // Recalculate everything and batch-write results in one transaction
         val allLines = dao.getLinesForFileSync(fileId)
         val effectiveRationalMode = rationalMode ?: _rationalMode.value
-        val calculatedLines = MathEngine.calculate(allLines, createFileContextLoader(fileId, effectiveRationalMode), rationalMode = effectiveRationalMode)
+        val effectiveDateFormat = getResolvedDateFormat()
+        val calculatedLines = MathEngine.calculate(
+            allLines, 
+            createFileContextLoader(fileId, effectiveRationalMode, effectiveDateFormat), 
+            rationalMode = effectiveRationalMode,
+            dateFormat = effectiveDateFormat
+        )
         val versionedLines = calculatedLines.map { it.copy(version = it.version + 1) }
         dao.updateLines(fileId, versionedLines)
     }
@@ -1018,7 +1024,14 @@ class CalculatorViewModel(
 
                 // Recalculate everything from the new line downward
                 val effectiveRationalMode = rationalMode ?: _rationalMode.value
-                val affectedLines = MathEngine.calculateFrom(updatedAllLines, insertIndex, createFileContextLoader(fileId, effectiveRationalMode), rationalMode = effectiveRationalMode)
+                val effectiveDateFormat = getResolvedDateFormat()
+                val affectedLines = MathEngine.calculateFrom(
+                    updatedAllLines, 
+                    insertIndex, 
+                    createFileContextLoader(fileId, effectiveRationalMode, effectiveDateFormat), 
+                    rationalMode = effectiveRationalMode,
+                    dateFormat = effectiveDateFormat
+                )
                 val versionedLines = affectedLines.map { it.copy(version = it.version + 1) }
                 dao.updateLines(fileId, versionedLines, updateTimestamp = false)
 
@@ -1068,7 +1081,14 @@ class CalculatorViewModel(
                 val updatedAllLines = dao.getLinesForFileSync(fileId)
                 val splitIndexInList = updatedAllLines.indexOfFirst { it.id == line.id }.coerceAtLeast(0)
                 val effectiveRationalMode = rationalMode ?: _rationalMode.value
-                val affectedLines = MathEngine.calculateFrom(updatedAllLines, splitIndexInList, createFileContextLoader(fileId, effectiveRationalMode), rationalMode = effectiveRationalMode)
+                val effectiveDateFormat = getResolvedDateFormat()
+                val affectedLines = MathEngine.calculateFrom(
+                    updatedAllLines, 
+                    splitIndexInList, 
+                    createFileContextLoader(fileId, effectiveRationalMode, effectiveDateFormat), 
+                    rationalMode = effectiveRationalMode,
+                    dateFormat = effectiveDateFormat
+                )
                 val versionedLines = affectedLines.map { it.copy(version = it.version + 1) }
                 dao.updateLines(fileId, versionedLines, updateTimestamp = false)
 
@@ -1104,7 +1124,14 @@ class CalculatorViewModel(
                 val updatedLines = dao.getLinesForFileSync(fileId)
                 val mergedIndex = updatedLines.indexOfFirst { it.id == prevLine.id }.coerceAtLeast(0)
                 val effectiveRationalMode = rationalMode ?: _rationalMode.value
-                val affectedLines = MathEngine.calculateFrom(updatedLines, mergedIndex, createFileContextLoader(fileId, effectiveRationalMode), rationalMode = effectiveRationalMode)
+                val effectiveDateFormat = getResolvedDateFormat()
+                val affectedLines = MathEngine.calculateFrom(
+                    updatedLines, 
+                    mergedIndex, 
+                    createFileContextLoader(fileId, effectiveRationalMode, effectiveDateFormat), 
+                    rationalMode = effectiveRationalMode,
+                    dateFormat = effectiveDateFormat
+                )
                 dao.updateLines(fileId, affectedLines, updateTimestamp = false)
             }
         }
@@ -1132,7 +1159,14 @@ class CalculatorViewModel(
                 // the deleted one now sits at the deleted line's old position.
                 if (deletedIndex in updatedLines.indices) {
                     val effectiveRationalMode = rationalMode ?: _rationalMode.value
-                    val affectedLines = MathEngine.calculateFrom(updatedLines, deletedIndex, createFileContextLoader(line.fileId, effectiveRationalMode), rationalMode = effectiveRationalMode)
+                    val effectiveDateFormat = getResolvedDateFormat()
+                    val affectedLines = MathEngine.calculateFrom(
+                        updatedLines, 
+                        deletedIndex, 
+                        createFileContextLoader(line.fileId, effectiveRationalMode, effectiveDateFormat), 
+                        rationalMode = effectiveRationalMode,
+                        dateFormat = effectiveDateFormat
+                    )
                     val versionedLines = affectedLines.map { l -> l.copy(version = l.version + 1) }
                     dao.updateLines(line.fileId, versionedLines)
                 }

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorViewModel.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorViewModel.kt
@@ -141,10 +141,18 @@ class CalculatorViewModel(
     )
     val syncEnabled: StateFlow<Boolean> = _syncEnabled
 
+    private val _dateFormat = MutableStateFlow(
+        prefs?.getString(Constants.PREF_DATE_FORMAT, Constants.DATE_FORMAT_AUTO) ?: Constants.DATE_FORMAT_AUTO
+    )
+    val dateFormat: StateFlow<String> = _dateFormat.asStateFlow()
+
     private val _syncFolderUri = MutableStateFlow(
         prefs?.getString(SyncManager.PREF_SYNC_FOLDER_URI, null)
     )
     val syncFolderUri: StateFlow<String?> = _syncFolderUri
+
+    private val _currentFileId = MutableStateFlow<Long?>(null)
+    val currentFileId: StateFlow<Long?> = _currentFileId.asStateFlow()
 
     private val _lastSyncAt = MutableStateFlow<Long?>(
         prefs?.getLong(SyncManager.PREF_LAST_SYNC_AT, 0L)?.takeIf { it > 0L }
@@ -275,14 +283,14 @@ class CalculatorViewModel(
         _restoreProgress.value = RestoreProgressState()
     }
 
-    private fun createFileContextLoader(currentFileId: Long, rationalMode: Boolean = false): FileContextLoader {
+    private fun createFileContextLoader(currentFileId: Long, rationalMode: Boolean = false, dateFormat: String = Constants.DATE_FORMAT_DMY): FileContextLoader {
         val cache = mutableMapOf<String, MathContext>()
         return object : FileContextLoader {
             override suspend fun loadContext(fileName: String, loadingStack: Set<String>): MathContext? {
                 cache[fileName]?.let { return it }
                 val file = dao.getFileByName(fileName) ?: return null
                 val lines = dao.getLinesForFileSync(file.id)
-                val context = MathEngine.buildVariableState(lines, this, loadingStack, rationalMode = rationalMode)
+                val context = MathEngine.buildVariableState(lines, this, loadingStack, rationalMode = rationalMode, dateFormat = dateFormat)
                 cache[fileName] = context
                 return context
             }
@@ -575,11 +583,36 @@ class CalculatorViewModel(
         prefs?.edit()?.putFloat(Constants.PREF_EDITOR_FONT_SIZE, clampedSize)?.apply()
     }
 
-    fun setRegionCode(code: String) {
+    fun setRegionCode(code: String, currentFileId: Long? = null) {
         _regionCode.value = code
         prefs?.edit()
             ?.putString(PREF_REGION_CODE, code)
             ?.apply()
+
+        // If date format is Auto, changing region may change the resolved date format
+        if (dateFormat.value == Constants.DATE_FORMAT_AUTO) {
+            currentFileId?.let { recalculateFile(it) }
+        }
+    }
+
+    fun setCurrentFileId(fileId: Long?) {
+        _currentFileId.value = fileId
+    }
+
+    fun setDateFormat(format: String, currentFileId: Long? = null) {
+        _dateFormat.value = format
+        prefs?.edit()?.putString(Constants.PREF_DATE_FORMAT, format)?.apply()
+        
+        // Recalculate current file if setting changed to ensure date inputs are re-evaluated
+        currentFileId?.let { recalculateFile(it) }
+    }
+
+    private fun getResolvedDateFormat(): String {
+        val pref = _dateFormat.value
+        if (pref != Constants.DATE_FORMAT_AUTO) return pref
+
+        val locale = RegionUtils.getLocaleForRegion(_regionCode.value)
+        return RegionUtils.getDefaultDateFormat(locale)
     }
 
     fun setGroupingSeparatorEnabled(enabled: Boolean) {
@@ -858,9 +891,24 @@ class CalculatorViewModel(
             calculationMutex.withLock {
                 val allLines = dao.getLinesForFileSync(fileId)
                 val effectiveRationalMode = rationalMode ?: _rationalMode.value
-                val calculatedLines = MathEngine.calculate(allLines, createFileContextLoader(fileId, effectiveRationalMode), rationalMode = effectiveRationalMode)
+                val effectiveDateFormat = getResolvedDateFormat()
+                val calculatedLines = MathEngine.calculate(
+                    allLines, 
+                    createFileContextLoader(fileId, effectiveRationalMode, effectiveDateFormat), 
+                    rationalMode = effectiveRationalMode,
+                    dateFormat = effectiveDateFormat
+                )
                 val versionedLines = calculatedLines.map { it.copy(version = it.version + 1) }
                 dao.updateLines(fileId, versionedLines, updateTimestamp = false)
+            }
+        }
+    }
+
+    fun recalculateAllFiles() {
+        viewModelScope.launch(ioDispatcher) {
+            val allFiles = dao.getAllFilesSync()
+            allFiles.forEach { file ->
+                recalculateFile(file.id)
             }
         }
     }
@@ -889,7 +937,14 @@ class CalculatorViewModel(
             // Recalculate only affected lines (from changedIndex onward), inheriting variable
             // state from the preceding lines without re-evaluating them.
             val effectiveRationalMode = rationalMode ?: _rationalMode.value
-            val affectedLines = MathEngine.calculateFrom(allLines, changedIndex, createFileContextLoader(updatedLine.fileId, effectiveRationalMode), rationalMode = effectiveRationalMode)
+            val effectiveDateFormat = getResolvedDateFormat()
+            val affectedLines = MathEngine.calculateFrom(
+                allLines, 
+                changedIndex, 
+                createFileContextLoader(updatedLine.fileId, effectiveRationalMode, effectiveDateFormat), 
+                rationalMode = effectiveRationalMode,
+                dateFormat = effectiveDateFormat
+            )
             val versionedLines = affectedLines.map { it.copy(version = it.version + 1) }
 
             // Batch-write all updated results in one DB transaction
@@ -903,7 +958,17 @@ class CalculatorViewModel(
             val allLines = dao.getLinesForFileSync(fileId)
             val targetIndex = allLines.indexOfFirst { it.id == targetLineId }
             val effectiveRationalMode = rationalMode ?: _rationalMode.value
-            if (targetIndex != -1) MathEngine.getErrorDetails(allLines, targetIndex, createFileContextLoader(fileId, effectiveRationalMode), setOf(file.name), rationalMode = effectiveRationalMode) else null
+            val effectiveDateFormat = getResolvedDateFormat()
+            if (targetIndex != -1) {
+                MathEngine.getErrorDetails(
+                    allLines, 
+                    targetIndex, 
+                    createFileContextLoader(fileId, effectiveRationalMode, effectiveDateFormat), 
+                    setOf(file.name), 
+                    rationalMode = effectiveRationalMode,
+                    dateFormat = effectiveDateFormat
+                )
+            } else null
         }
     }
 

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/components/DateFormatSelectorDialog.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/components/DateFormatSelectorDialog.kt
@@ -1,0 +1,98 @@
+package com.vishaltelangre.nerdcalci.ui.components
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.vishaltelangre.nerdcalci.core.Constants
+
+@Composable
+fun DateFormatSelectorDialog(
+    visible: Boolean,
+    currentFormat: String,
+    autoLabel: String,
+    onSelect: (String) -> Unit,
+    onDismiss: () -> Unit
+) {
+    if (!visible) return
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Preferred input date format") },
+        text = {
+            val options = listOf(
+                Constants.DATE_FORMAT_AUTO to autoLabel,
+                Constants.DATE_FORMAT_DMY to "DD/MM/YYYY",
+                Constants.DATE_FORMAT_MDY to "MM/DD/YYYY",
+                Constants.DATE_FORMAT_YMD to "YYYY/MM/DD"
+            )
+
+            LazyColumn(
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.heightIn(max = 400.dp)
+            ) {
+                items(options) { (format, label) ->
+                    DateFormatOption(
+                        label = label,
+                        isSelected = currentFormat == format,
+                        onClick = { onSelect(format) }
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Close")
+            }
+        }
+    )
+}
+
+@Composable
+private fun DateFormatOption(
+    label: String,
+    isSelected: Boolean,
+    onClick: () -> Unit
+) {
+    Card(
+        onClick = onClick,
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = if (isSelected)
+                MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.5f)
+            else
+                MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
+        )
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = label,
+                modifier = Modifier.weight(1f),
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
+                color = if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface
+            )
+            if (isSelected) {
+                Icon(
+                    imageVector = Icons.Default.Check,
+                    contentDescription = "Selected",
+                    tint = MaterialTheme.colorScheme.primary
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/settings/CalculatorSettingsScreen.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/settings/CalculatorSettingsScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.BorderHorizontal
+import androidx.compose.material.icons.filled.CalendarToday
 import androidx.compose.material.icons.filled.Calculate
 import androidx.compose.material.icons.filled.Chat
 import androidx.compose.material.icons.filled.FlashOn
@@ -56,8 +57,10 @@ fun CalculatorSettingsScreen(
     onGroupingSeparatorEnabledChange: (Boolean) -> Unit,
     showPrecisionEllipsis: Boolean,
     onShowPrecisionEllipsisChange: (Boolean) -> Unit,
-    editorFontSize: Float,
     onEditorFontSizeChange: (Float) -> Unit,
+    editorFontSize: Float,
+    dateFormat: String,
+    onDateFormatChange: (String) -> Unit,
     showLineNumbers: Boolean,
     onShowLineNumbersChange: (Boolean) -> Unit,
     showSuggestions: Boolean,
@@ -69,10 +72,31 @@ fun CalculatorSettingsScreen(
     onBack: () -> Unit
 ) {
     var showRegionDialog by remember { mutableStateOf(false) }
+    var showDateFormatDialog by remember { mutableStateOf(false) }
     var lastPrecision by remember { mutableStateOf(if (precision == Constants.PRECISION_OFF) Constants.DEFAULT_PRECISION else precision) }
     var sliderValue by remember(precision) { mutableStateOf(if (precision == Constants.PRECISION_OFF) lastPrecision.toFloat() else precision.toFloat()) }
     var editorFontSizeSlider by remember(editorFontSize) { mutableStateOf(editorFontSize) }
     val availableRegions = remember { RegionUtils.getAvailableRegions() }
+    val currentRegionName = remember(regionCode, availableRegions) {
+        if (regionCode == RegionUtils.SYSTEM_DEFAULT) {
+            availableRegions.find { it.first == java.util.Locale.getDefault().country }?.second
+                ?: java.util.Locale.getDefault().displayCountry
+        } else {
+            availableRegions.find { it.first == regionCode }?.second ?: regionCode
+        }
+    }
+
+    val resolvedAutoLabel = remember(regionCode, currentRegionName) {
+        val locale = RegionUtils.getLocaleForRegion(regionCode)
+        val resolved = RegionUtils.getDefaultDateFormat(locale)
+        val formatDisplay = when (resolved) {
+            Constants.DATE_FORMAT_DMY -> "DD/MM/YYYY"
+            Constants.DATE_FORMAT_MDY -> "MM/DD/YYYY"
+            Constants.DATE_FORMAT_YMD -> "YYYY/MM/DD"
+            else -> resolved
+        }
+        "Auto ($formatDisplay based on $currentRegionName)"
+    }
 
     Scaffold(
         topBar = {
@@ -164,15 +188,35 @@ fun CalculatorSettingsScreen(
             Text(
                 text = remember(regionCode, groupingSeparatorEnabled, precision) {
                     MathEngine.formatDisplayResult(
-                        "12345678.90",
-                        precision,
-                        regionCode = regionCode,
-                        groupingSeparatorEnabled = groupingSeparatorEnabled
+                        rawResult = "12345678.90",
+                        precision = precision,
+                        groupingSeparatorEnabled = groupingSeparatorEnabled,
+                        regionCode = regionCode
                     )
                 },
-                style = MaterialTheme.typography.labelLarge.copy(fontFamily = FiraCodeFamily),
+                style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(horizontal = 80.dp).padding(bottom = 16.dp)
+                modifier = Modifier.padding(start = 72.dp, bottom = 16.dp),
+                fontFamily = FiraCodeFamily
+            )
+
+            SettingsDropdownItem(
+                icon = Icons.Default.CalendarToday,
+                title = "Preferred input date format",
+                value = if (dateFormat == Constants.DATE_FORMAT_AUTO) resolvedAutoLabel else when (dateFormat) {
+                    Constants.DATE_FORMAT_DMY -> "DD/MM/YYYY"
+                    Constants.DATE_FORMAT_MDY -> "MM/DD/YYYY"
+                    Constants.DATE_FORMAT_YMD -> "YYYY/MM/DD"
+                    else -> dateFormat
+                },
+                onClick = { showDateFormatDialog = true }
+            )
+
+            Text(
+                text = "Used to resolve numeric dates like 10/05/2024. Separators like / - . are always supported interchangeably.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(start = 72.dp, end = 16.dp, bottom = 16.dp)
             )
 
             if (precision != Constants.PRECISION_OFF) {
@@ -265,5 +309,16 @@ fun CalculatorSettingsScreen(
             showRegionDialog = false
         },
         onDismiss = { showRegionDialog = false }
+    )
+
+    com.vishaltelangre.nerdcalci.ui.components.DateFormatSelectorDialog(
+        visible = showDateFormatDialog,
+        currentFormat = dateFormat,
+        autoLabel = resolvedAutoLabel,
+        onSelect = {
+            onDateFormatChange(it)
+            showDateFormatDialog = false
+        },
+        onDismiss = { showDateFormatDialog = false }
     )
 }

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/utils/RegionUtils.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/utils/RegionUtils.kt
@@ -1,6 +1,7 @@
 package com.vishaltelangre.nerdcalci.utils
 
 import java.util.Locale
+import com.vishaltelangre.nerdcalci.core.Constants
 
 object RegionUtils {
     const val SYSTEM_DEFAULT = "system"
@@ -31,6 +32,25 @@ object RegionUtils {
             if (enMatch != null) return@getOrPut enMatch
 
             available.find { it.country == regionCode } ?: Locale("", regionCode)
+        }
+    }
+
+    /**
+     * Determines the natural date format order for a given locale.
+     * Uses java.text.DateFormat to inspect the short date pattern.
+     */
+    fun getDefaultDateFormat(locale: Locale): String {
+        return try {
+            val df = java.text.DateFormat.getDateInstance(java.text.DateFormat.SHORT, locale)
+            val pattern = (df as? java.text.SimpleDateFormat)?.toPattern() ?: ""
+            when {
+                pattern.startsWith("d", ignoreCase = true) -> Constants.DATE_FORMAT_DMY
+                pattern.startsWith("M", ignoreCase = true) -> Constants.DATE_FORMAT_MDY
+                pattern.startsWith("y", ignoreCase = true) -> Constants.DATE_FORMAT_YMD
+                else -> Constants.DATE_FORMAT_DMY // Fallback for most of the world
+            }
+        } catch (_: Exception) {
+            Constants.DATE_FORMAT_DMY
         }
     }
 }

--- a/app/src/test/java/com/vishaltelangre/nerdcalci/core/DateStringParserTest.kt
+++ b/app/src/test/java/com/vishaltelangre/nerdcalci/core/DateStringParserTest.kt
@@ -1,11 +1,42 @@
 package com.vishaltelangre.nerdcalci.core
 
 import org.junit.Assert.*
+import org.junit.After
+import org.junit.Before
 import org.junit.Test
 import java.time.LocalDate
 import java.time.ZoneId
+import java.util.Locale
 
 class DateStringParserTest {
+
+    private var originalLocale: Locale? = null
+
+    @Before
+    fun setup() {
+        originalLocale = Locale.getDefault()
+        // Fix to US locale by default for consistent test behavior
+        Locale.setDefault(Locale.US)
+    }
+
+    @After
+    fun tearDown() {
+        originalLocale?.let { Locale.setDefault(it) }
+    }
+
+    @Test
+    fun `resolves numeric format automatically based on locale`() {
+        // MDY locale (e.g. US)
+        Locale.setDefault(Locale.US)
+        assertEquals(LocalDate.of(2024, 12, 25), (DateStringParser.parse("12/25/2024") as DateTimeResult.Date).date)
+
+        // DMY locale (e.g. UK)
+        Locale.setDefault(Locale.UK)
+        assertEquals(LocalDate.of(2024, 12, 25), (DateStringParser.parse("25/12/2024") as DateTimeResult.Date).date)
+        
+        // Restore to US for other tests
+        Locale.setDefault(Locale.US)
+    }
 
     @Test
     fun `parses ISO 8601 format`() {
@@ -49,16 +80,40 @@ class DateStringParserTest {
     }
 
     @Test
-    fun `rejects ambiguous numeric formats`() {
-        val e1 = assertThrows(EvalException::class.java) {
-            DateStringParser.parse("12/02/1988")
+    fun `parses regional numeric formats`() {
+        // DMY
+        assertEquals(LocalDate.of(2024, 12, 25), (DateStringParser.parse("25/12/2024", Constants.DATE_FORMAT_DMY) as DateTimeResult.Date).date)
+        // MDY
+        assertEquals(LocalDate.of(2024, 12, 25), (DateStringParser.parse("12/25/2024", Constants.DATE_FORMAT_MDY) as DateTimeResult.Date).date)
+        // YMD
+        assertEquals(LocalDate.of(2024, 12, 25), (DateStringParser.parse("2024/12/25", Constants.DATE_FORMAT_YMD) as DateTimeResult.Date).date)
+    }
+
+    @Test
+    fun `supports interchangeable separators in numeric formats`() {
+        assertEquals(LocalDate.of(2024, 12, 25), (DateStringParser.parse("25.12-2024", Constants.DATE_FORMAT_DMY) as DateTimeResult.Date).date)
+        assertEquals(LocalDate.of(2024, 12, 25), (DateStringParser.parse("12-25.2024", Constants.DATE_FORMAT_MDY) as DateTimeResult.Date).date)
+    }
+
+    @Test
+    fun `rejects 2-digit years in numeric formats`() {
+        val e = assertThrows(EvalException::class.java) {
+            DateStringParser.parse("11/11/11", Constants.DATE_FORMAT_DMY)
         }
-        assertTrue(e1.message!!.contains("Ambiguous"))
+        assertTrue(e.message!!.contains("Year must be 4 digits"))
+    }
+
+    @Test
+    fun `rejects out of range components in numeric formats`() {
+        val e1 = assertThrows(EvalException::class.java) {
+            DateStringParser.parse("32/01/2024", Constants.DATE_FORMAT_DMY)
+        }
+        assertTrue(e1.message!!.contains("out of range"))
 
         val e2 = assertThrows(EvalException::class.java) {
-            DateStringParser.parse("01.05.2005")
+            DateStringParser.parse("13/01/2024", Constants.DATE_FORMAT_MDY)
         }
-        assertTrue(e2.message!!.contains("Ambiguous"))
+        assertTrue(e2.message!!.contains("out of range"))
     }
 
     @Test
@@ -67,6 +122,15 @@ class DateStringParserTest {
             DateStringParser.parse("February 30, 2019")
         }
         assertTrue(e.message!!.contains("Invalid date"))
+    }
+
+    @Test
+    fun `rejects regional (non-English) month names`() {
+        val e = assertThrows(EvalException::class.java) {
+            // French for April is "Avril"
+            DateStringParser.parse("1 Avril 2024")
+        }
+        assertTrue(e.message!!.contains("Unknown month name"))
     }
 
     @Test

--- a/app/src/test/java/com/vishaltelangre/nerdcalci/core/DateTimeFeaturesTest.kt
+++ b/app/src/test/java/com/vishaltelangre/nerdcalci/core/DateTimeFeaturesTest.kt
@@ -184,6 +184,15 @@ class DateTimeFeaturesTest {
     }
 
     @Test
+    fun `date interval with time cross respects incomplete days`() = testCalculate(
+        "datetime(1981, 2, 14, 18, 32, 0) to datetime(2026, 5, 3, 14, 49, 9)" // [0]
+    ) { results ->
+        // Feb 14 18:32 to May 3 14:49:09
+        // 45y 2m 18d 20h 17min 9s
+        assertEquals("45 y 2 mo 18 d 20 h 17 min 9 s", results[0].result)
+    }
+
+    @Test
     fun `inclusive logic for dates vs datetimes`() = testCalculate(
         "datetime(2024, 1, 1, 12, 0, 0) through datetime(2024, 1, 2, 12, 0, 0) in hours", // [0] datetimes, no padding -> 24h
         "date(2024, 1, 1) through date(2024, 1, 1) in hours",                           // [1] date through same date -> 24h (padding applied)

--- a/app/src/test/java/com/vishaltelangre/nerdcalci/core/DateTimeFeaturesTest.kt
+++ b/app/src/test/java/com/vishaltelangre/nerdcalci/core/DateTimeFeaturesTest.kt
@@ -354,7 +354,8 @@ class DateTimeFeaturesTest {
         "datetimeZ(2024, 1, 1, 12, 0, 0, \"UTC\") in \"Invalid/Zone\"",
         "1.5 days ago",                         // Fractional duration (truncates)
         "date(2023, 12, 31) + 1y 1mo 1d",      // Multi-component overflow
-        "parseDate(\"12/02/1988\")"            // defaults to DMY
+        "parseDate(\"12/02/1988\")",           // defaults to DMY
+        dateFormat = Constants.DATE_FORMAT_DMY
     ) { results ->
         assertEquals("Err", results[0].result)
         assertEquals("Err", results[1].result)

--- a/app/src/test/java/com/vishaltelangre/nerdcalci/core/DateTimeFeaturesTest.kt
+++ b/app/src/test/java/com/vishaltelangre/nerdcalci/core/DateTimeFeaturesTest.kt
@@ -50,6 +50,33 @@ class DateTimeFeaturesTest {
     }
 
     @Test
+    fun `regional numeric date parsing`() {
+        // Test with DMY preference
+        testCalculate(
+            "parseDate(\"25/12/2024\")",
+            dateFormat = Constants.DATE_FORMAT_DMY
+        ) { results ->
+            assertEquals("Dec 25, 2024", results[0].result)
+        }
+
+        // Test with MDY preference
+        testCalculate(
+            "parseDate(\"12/25/2024\")",
+            dateFormat = Constants.DATE_FORMAT_MDY
+        ) { results ->
+            assertEquals("Dec 25, 2024", results[0].result)
+        }
+
+        // Test with YMD preference
+        testCalculate(
+            "parseDate(\"2024/12/25\")",
+            dateFormat = Constants.DATE_FORMAT_YMD
+        ) { results ->
+            assertEquals("Dec 25, 2024", results[0].result)
+        }
+    }
+
+    @Test
     fun `roundtrip parsing via iso8601 and timestamp`() = testCalculate(
         "d = date(2024, 1, 1)",
         "parseDate(d as iso8601)",
@@ -327,7 +354,7 @@ class DateTimeFeaturesTest {
         "datetimeZ(2024, 1, 1, 12, 0, 0, \"UTC\") in \"Invalid/Zone\"",
         "1.5 days ago",                         // Fractional duration (truncates)
         "date(2023, 12, 31) + 1y 1mo 1d",      // Multi-component overflow
-        "parseDate(\"12/02/1988\")"            // Ambiguous format
+        "parseDate(\"12/02/1988\")"            // defaults to DMY
     ) { results ->
         assertEquals("Err", results[0].result)
         assertEquals("Err", results[1].result)
@@ -338,7 +365,7 @@ class DateTimeFeaturesTest {
         assertEquals("Err", results[6].result)
         assertNotEquals("Err", results[7].result) // Truncates to 1 day
         assertEquals("Feb 1, 2025", results[8].result)
-        assertEquals("Err", results[9].result)
+        assertEquals("Feb 12, 1988", results[9].result)
     }
 
     @Test

--- a/app/src/test/java/com/vishaltelangre/nerdcalci/core/MathEngineTest.kt
+++ b/app/src/test/java/com/vishaltelangre/nerdcalci/core/MathEngineTest.kt
@@ -120,6 +120,13 @@ class MathEngineTest {
     }
 
     @Test
+    fun `variable modulo variable`() = testCalculate("a = 10", "b = 3", "a % b") { result ->
+        assertEquals("10.0", result[0].result)
+        assertEquals("3.0", result[1].result)
+        assertEquals("1.0", result[2].result)
+    }
+
+    @Test
     fun `total throws dimension mismatch error for mixed units`() {
         testCalculate("4kg", "5 hour", "3 kph", "total") { result ->
         assertError("Summation of `Kilogram` and `Hour` is not supported", result, 3)
@@ -532,6 +539,18 @@ class MathEngineTest {
     }
 
     @Test
+    fun `variable percentage of variable`() = testCalculate("a = 10", "b = 200", "a% of b") { result ->
+        assertEquals("10.0", result[0].result)
+        assertEquals("200.0", result[1].result)
+        assertEquals("20.0", result[2].result)
+    }
+
+    @Test
+    fun `expression as percentage`() = testCalculate("(5+5)% of 200") { result ->
+        assertEquals("20.0", result[0].result)
+    }
+
+    @Test
     fun `percentage of quantity preserves unit`() = testCalculate("10000g", "10% of _", "_ + 9kg") { result ->
         assertEquals("10000.0 g", result[0].result)
         assertEquals("1000.0 g", result[1].result)
@@ -585,6 +604,13 @@ class MathEngineTest {
     fun `percentage off variable`() = testCalculate("original = 500", "30% off original") { result ->
         assertEquals("500.0", result[0].result)
         assertEquals("350.0", result[1].result)
+    }
+
+    @Test
+    fun `variable percentage off variable`() = testCalculate("a = 10", "b = 200", "a% off b") { result ->
+        assertEquals("10.0", result[0].result)
+        assertEquals("200.0", result[1].result)
+        assertEquals("180.0", result[2].result)
     }
 
     @Test

--- a/app/src/test/java/com/vishaltelangre/nerdcalci/core/MathTestUtils.kt
+++ b/app/src/test/java/com/vishaltelangre/nerdcalci/core/MathTestUtils.kt
@@ -30,10 +30,11 @@ fun createLines(vararg expressions: String, fileId: Long = 1L): List<LineEntity>
 suspend fun testCalculate(
     vararg expressions: String,
     loader: FileContextLoader? = null,
-    rationalMode: Boolean = false
+    rationalMode: Boolean = false,
+    dateFormat: String = Constants.DATE_FORMAT_DMY
 ): List<LineEntity> {
     val lines = createLines(*expressions)
-    return MathEngine.calculate(lines, loader, rationalMode)
+    return MathEngine.calculate(lines, loader, rationalMode, dateFormat)
 }
 
 /**
@@ -43,9 +44,10 @@ fun testCalculate(
     vararg expressions: String,
     loader: FileContextLoader? = null,
     rationalMode: Boolean = false,
+    dateFormat: String = Constants.DATE_FORMAT_DMY,
     block: suspend (List<LineEntity>) -> kotlin.Unit
 ) = runBlocking {
-    val results = testCalculate(*expressions, loader = loader, rationalMode = rationalMode)
+    val results = testCalculate(*expressions, loader = loader, rationalMode = rationalMode, dateFormat = dateFormat)
     block(results)
 }
 

--- a/app/src/test/java/com/vishaltelangre/nerdcalci/core/MathTestUtils.kt
+++ b/app/src/test/java/com/vishaltelangre/nerdcalci/core/MathTestUtils.kt
@@ -31,7 +31,7 @@ suspend fun testCalculate(
     vararg expressions: String,
     loader: FileContextLoader? = null,
     rationalMode: Boolean = false,
-    dateFormat: String = Constants.DATE_FORMAT_DMY
+    dateFormat: String = Constants.DATE_FORMAT_AUTO
 ): List<LineEntity> {
     val lines = createLines(*expressions)
     return MathEngine.calculate(lines, loader, rationalMode, dateFormat)
@@ -44,7 +44,7 @@ fun testCalculate(
     vararg expressions: String,
     loader: FileContextLoader? = null,
     rationalMode: Boolean = false,
-    dateFormat: String = Constants.DATE_FORMAT_DMY,
+    dateFormat: String = Constants.DATE_FORMAT_AUTO,
     block: suspend (List<LineEntity>) -> kotlin.Unit
 ) = runBlocking {
     val results = testCalculate(*expressions, loader = loader, rationalMode = rationalMode, dateFormat = dateFormat)

--- a/fastlane/metadata/android/en-US/changelogs/401.txt
+++ b/fastlane/metadata/android/en-US/changelogs/401.txt
@@ -1,0 +1,3 @@
+- Added support for regional date format preferences (DD/MM/YYYY, MM/DD/YYYY, YYYY/MM/DD) for numeric inputs (Issue #162).
+- Fixed an off-by-one error in date intervals with time components (Issue #163).
+- Fixed a bug where variable percentages (e.g., `a% of b`) resulted in an error.


### PR DESCRIPTION
- Fixes https://github.com/vishaltelangre/NerdCalci/issues/162.
- Fixes https://github.com/vishaltelangre/NerdCalci/issues/163.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for regional numeric date format preferences (DD/MM/YYYY, MM/DD/YYYY, YYYY/MM/DD) for date inputs
  * New settings option to configure preferred input date format

* **Bug Fixes**
  * Fixed date interval off-by-one errors when intervals end on incomplete days
  * Fixed errors with variable percentage expressions like `a% of b`

* **Documentation**
  * Updated reference materials for supported date formats and parsing behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->