### PR TITLE
Fix overlapping text in Help screen tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.1] - 2026-05-04
+### Fixed
+- Fixed overlapping text in Help screen tables (Issue #175).
+
 ## [4.1.0] - 2026-05-04
 ### Added
 - Added Find-in-page to Help screen (Issue `#166`).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
     defaultConfig {
         applicationId = "com.vishaltelangre.nerdcalci"
         minSdk = 23
-        versionCode = 410
-        versionName = "4.1.0"
+        versionCode = 411
+        versionName = "4.1.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/help/HelpScreen.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/help/HelpScreen.kt
@@ -308,6 +308,7 @@ fun HelpScreen(onBack: () -> Unit) {
                 HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
             }
             HelpScreenContent(
+                markwon = markwon,
                 renderedText = renderedText,
                 scrollState = scrollState,
                 searchQuery = searchQuery,
@@ -444,6 +445,7 @@ private fun scrollToAnchor(
 
 @Composable
 private fun HelpScreenContent(
+    markwon: Markwon,
     renderedText: android.text.Spanned?,
     scrollState: ScrollState,
     searchQuery: String,
@@ -515,7 +517,7 @@ private fun HelpScreenContent(
                     }
                 }
 
-                textView.text = spannable
+                markwon.setParsedMarkdown(textView, spannable)
             }
         )
     }

--- a/fastlane/metadata/android/en-US/changelogs/411.txt
+++ b/fastlane/metadata/android/en-US/changelogs/411.txt
@@ -1,0 +1,1 @@
+- Fixed overlapping text in Help screen tables (Issue #175).


### PR DESCRIPTION
Fixes https://github.com/vishaltelangre/NerdCalci/issues/175.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed overlapping text in Help screen tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->