### PR TITLE
Support multiline copy-paste

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.7.0] - 2026-05-19
+### Added
+- Added ability to select multiple lines for copying either by tapping on line number or using "Select lines..." menu (Issue #75).
+- Added multi-line paste support (Issue #75).
+
 ## [4.6.0] - 2026-05-16
 ### Added
 - Added `grand_total` and `grand_sum` dynamic variables to calculate the sum of all results in the file above the current line, ignoring block boundaries (Issue #89).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
     defaultConfig {
         applicationId = "com.vishaltelangre.nerdcalci"
         minSdk = 23
-        versionCode = 460
-        versionName = "4.6.0"
+        versionCode = 470
+        versionName = "4.7.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorScreen.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorScreen.kt
@@ -823,12 +823,13 @@ fun CalculatorScreen(
                                         .joinToString("\n")
                                     viewModel.copyToClipboard(context, text, "NerdCalci Lines")
                                     clearSelection()
-                                }
+                                },
+                                enabled = selectedIndices.isNotEmpty()
                             ) {
                                 Icon(
                                     Icons.Default.ContentCopy,
                                     "Copy selected lines",
-                                    tint = MaterialTheme.colorScheme.onSurface
+                                    tint = if (selectedIndices.isNotEmpty()) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f)
                                 )
                             }
                         } else {
@@ -2081,27 +2082,32 @@ private fun LineRow(
                         // Using indexOf('\n') is more reliable than selection.start because
                         // selection.start can jump ahead after character insertion.
                         if (newValue.text.contains("\n")) {
-                            val addedLength = newValue.text.length - textFieldValue.text.length
-                            if (addedLength > 1) {
-                                // Multi-line Clipboard Paste Interception
-                                val clipboard = context.getSystemService(android.content.Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
-                                val pastedText = clipboard.primaryClip?.getItemAt(0)?.text?.toString() ?: ""
-                                if (pastedText.contains("\n")) {
-                                    val pastedLines = pastedText.split(Regex("\\r?\\n"))
-                                    if (pastedLines.size > 1) {
-                                        val cursorPos = textFieldValue.selection.start
-                                        val cursorPosInExpr = if (lineNumber > 1) {
-                                            (cursorPos - 1).coerceAtLeast(0)
-                                        } else {
-                                            cursorPos
-                                        }
-                                        val firstChunk = pastedLines.first()
-                                        val middleLines = pastedLines.subList(1, pastedLines.size - 1)
-                                        val lastChunk = pastedLines.last()
+                            // Check if this is a multi-line clipboard paste
+                            val clipboard = context.getSystemService(android.content.Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
+                            val pastedText = clipboard.primaryClip?.getItemAt(0)?.text?.toString() ?: ""
 
-                                        onPasteLines(cursorPosInExpr, firstChunk, middleLines, lastChunk)
-                                        return@BasicTextField
+                            val selStart = minOf(textFieldValue.selection.start, textFieldValue.selection.end)
+                            val insertedText = if (selStart <= newValue.selection.start && newValue.selection.start <= newValue.text.length) {
+                                newValue.text.substring(selStart, newValue.selection.start)
+                            } else {
+                                ""
+                            }
+
+                            if (pastedText.contains("\n") && insertedText == pastedText) {
+                                val pastedLines = pastedText.split(Regex("\\r?\\n"))
+                                if (pastedLines.size > 1) {
+                                    val cursorPos = textFieldValue.selection.start
+                                    val cursorPosInExpr = if (lineNumber > 1) {
+                                        (cursorPos - 1).coerceAtLeast(0)
+                                    } else {
+                                        cursorPos
                                     }
+                                    val firstChunk = pastedLines.first()
+                                    val middleLines = pastedLines.subList(1, pastedLines.size - 1)
+                                    val lastChunk = pastedLines.last()
+
+                                    onPasteLines(cursorPosInExpr, firstChunk, middleLines, lastChunk)
+                                    return@BasicTextField
                                 }
                             }
 

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorScreen.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorScreen.kt
@@ -69,6 +69,7 @@ import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.PictureAsPdf
 import androidx.compose.material.icons.filled.ViewHeadline
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.DropdownMenu
@@ -96,6 +97,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.navigation.NavHostController
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.derivedStateOf
@@ -595,6 +597,81 @@ fun CalculatorScreen(
     // Track which line is currently focused by the user
     var currentlyFocusedLineId by remember { mutableStateOf<Long?>(null) }
 
+    // Range selection state (for multi-line copy)
+    var selectionAnchorIndex by remember { mutableStateOf<Int?>(null) }
+    var selectionPivotIndex by remember { mutableStateOf<Int?>(null) }
+    var enteringSelectionMode by remember { mutableStateOf(false) }
+
+    val isInSelectionMode = selectionAnchorIndex != null || enteringSelectionMode
+
+    val selectedIndices: Set<Int> = remember(selectionAnchorIndex, selectionPivotIndex) {
+        val a = selectionAnchorIndex ?: return@remember emptySet()
+        val b = selectionPivotIndex ?: a
+        (minOf(a, b)..maxOf(a, b)).toSet()
+    }
+
+    fun clearSelection() {
+        selectionAnchorIndex = null
+        selectionPivotIndex = null
+        enteringSelectionMode = false
+    }
+
+    fun handleSelectionTap(tappedIndex: Int) {
+        val anchor = selectionAnchorIndex
+        val pivot = selectionPivotIndex
+        if (anchor != null && pivot != null && selectedIndices.contains(tappedIndex)) {
+            if (tappedIndex == anchor) {
+                clearSelection()
+            } else if (anchor < pivot) {
+                val newPivot = tappedIndex - 1
+                if (newPivot < anchor) {
+                    clearSelection()
+                } else {
+                    selectionPivotIndex = newPivot
+                }
+            } else {
+                val newPivot = tappedIndex + 1
+                if (newPivot > anchor) {
+                    clearSelection()
+                } else {
+                    selectionPivotIndex = newPivot
+                }
+            }
+        } else {
+            if (anchor != null && pivot != null) {
+                val minVal = minOf(anchor, pivot)
+                val maxVal = maxOf(anchor, pivot)
+                if (tappedIndex < minVal) {
+                    selectionAnchorIndex = maxVal
+                    selectionPivotIndex = tappedIndex
+                } else if (tappedIndex > maxVal) {
+                    selectionAnchorIndex = minVal
+                    selectionPivotIndex = tappedIndex
+                } else {
+                    selectionPivotIndex = tappedIndex
+                }
+            } else {
+                selectionAnchorIndex = tappedIndex
+                selectionPivotIndex = tappedIndex
+            }
+        }
+        enteringSelectionMode = false
+    }
+
+    BackHandler(enabled = isInSelectionMode) {
+        clearSelection()
+    }
+
+    val focusManager = LocalFocusManager.current
+
+    LaunchedEffect(isInSelectionMode) {
+        if (isInSelectionMode) {
+            focusManager.clearFocus()
+            focusLineId = null
+            focusCursorPosition = 0
+        }
+    }
+
     // Track toolbar text insertion requests (used for inserting symbols using custom keyboard shortcuts)
     var insertTextRequest by remember { mutableStateOf<Pair<Long, String>?>(null) }
     // Check if keyboard is visible
@@ -680,77 +757,103 @@ fun CalculatorScreen(
             Column {
                 TopAppBar(
                     title = {
-                        Column(
-                            modifier = if (!isScratchpad && !isLocked) {
-                                Modifier.clickable { showRenameDialog = true }
-                            } else {
-                                Modifier
-                            }
-                        ) {
-                            Row(verticalAlignment = Alignment.CenterVertically) {
-                                Text(
-                                    text = fileName,
-                                    color = MaterialTheme.colorScheme.onSurface,
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis
-                                )
-                                if (isLocked) {
-                                    Spacer(modifier = Modifier.width(4.dp))
-                                    Icon(
-                                        Icons.Default.Lock,
-                                        contentDescription = "Locked",
-                                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                                        modifier = Modifier.size(16.dp)
+                        if (isInSelectionMode) {
+                            Text(
+                                text = "${selectedIndices.size} line${if (selectedIndices.size == 1) "" else "s"} selected",
+                                color = MaterialTheme.colorScheme.onSurface,
+                                style = MaterialTheme.typography.titleMedium
+                            )
+                        } else {
+                            Column(
+                                modifier = if (!isScratchpad && !isLocked) {
+                                    Modifier.clickable { showRenameDialog = true }
+                                } else {
+                                    Modifier
+                                }
+                            ) {
+                                Row(verticalAlignment = Alignment.CenterVertically) {
+                                    Text(
+                                        text = fileName,
+                                        color = MaterialTheme.colorScheme.onSurface,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis
+                                    )
+                                    if (isLocked) {
+                                        Spacer(modifier = Modifier.width(4.dp))
+                                        Icon(
+                                            Icons.Default.Lock,
+                                            contentDescription = "Locked",
+                                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                            modifier = Modifier.size(16.dp)
+                                        )
+                                    }
+                                }
+                                if (isScratchpad) {
+                                    Text(
+                                        text = "Temporary file • Changes not saved",
+                                        style = MaterialTheme.typography.bodySmall.copy(fontSize = 10.sp),
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
                                     )
                                 }
-                            }
-                            if (isScratchpad) {
-                                Text(
-                                    text = "Temporary file • Changes not saved",
-                                    style = MaterialTheme.typography.bodySmall.copy(fontSize = 10.sp),
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                                )
-                            }
-                            if (isLocked) {
-                                Text(
-                                    text = "Locked file • Cannot be modified",
-                                    style = MaterialTheme.typography.bodySmall.copy(fontSize = 10.sp),
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                                )
+                                if (isLocked) {
+                                    Text(
+                                        text = "Locked file • Cannot be modified",
+                                        style = MaterialTheme.typography.bodySmall.copy(fontSize = 10.sp),
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
                             }
                         }
                     },
                     navigationIcon = {
-                        IconButton(onClick = handleBack) {
+                        IconButton(onClick = if (isInSelectionMode) ::clearSelection else handleBack) {
                             Icon(
-                                Icons.AutoMirrored.Filled.ArrowBack,
-                                "Back",
+                                if (isInSelectionMode) Icons.Default.Close else Icons.AutoMirrored.Filled.ArrowBack,
+                                if (isInSelectionMode) "Cancel selection" else "Back",
                                 tint = MaterialTheme.colorScheme.onSurface
                             )
                         }
                     },
                     actions = {
-                        if (!isLocked) {
+                        if (isInSelectionMode) {
                             IconButton(
-                                onClick = { viewModel.undo(fileId, effectiveRationalMode) },
-                                enabled = canUndo
+                                onClick = {
+                                    val text = selectedIndices.sorted()
+                                        .mapNotNull { lines.getOrNull(it)?.expression }
+                                        .joinToString("\n")
+                                    viewModel.copyToClipboard(context, text, "NerdCalci Lines")
+                                    clearSelection()
+                                }
                             ) {
                                 Icon(
-                                    Icons.AutoMirrored.Filled.Undo,
-                                    "Undo",
-                                    tint = if (canUndo) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurfaceVariant
+                                    Icons.Default.ContentCopy,
+                                    "Copy selected lines",
+                                    tint = MaterialTheme.colorScheme.onSurface
                                 )
                             }
+                        } else {
+                            if (!isLocked) {
+                                IconButton(
+                                    onClick = { viewModel.undo(fileId, effectiveRationalMode) },
+                                    enabled = canUndo
+                                ) {
+                                    Icon(
+                                        Icons.AutoMirrored.Filled.Undo,
+                                        "Undo",
+                                        tint = if (canUndo) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
 
-                            IconButton(
-                                onClick = { viewModel.redo(fileId, effectiveRationalMode) },
-                                enabled = canRedo
-                            ) {
-                                Icon(
-                                    Icons.AutoMirrored.Filled.Redo,
-                                    "Redo",
-                                    tint = if (canRedo) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurfaceVariant
-                                )
+                                IconButton(
+                                    onClick = { viewModel.redo(fileId, effectiveRationalMode) },
+                                    enabled = canRedo
+                                ) {
+                                    Icon(
+                                        Icons.AutoMirrored.Filled.Redo,
+                                        "Redo",
+                                        tint = if (canRedo) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
                             }
                         }
 
@@ -782,6 +885,19 @@ fun CalculatorScreen(
                                     onClick = {
                                         showMenu = false
                                         onHelp()
+                                    }
+                                )
+                                DropdownMenuItem(
+                                    text = { Text("Select lines…") },
+                                    leadingIcon = {
+                                        Icon(
+                                            Icons.Default.FormatListNumbered,
+                                            contentDescription = null
+                                        )
+                                    },
+                                    onClick = {
+                                        showMenu = false
+                                        enteringSelectionMode = true
                                     }
                                 )
                                 HorizontalDivider()
@@ -1248,7 +1364,33 @@ fun CalculatorScreen(
                             viewModel.copyToClipboard(context, result)
                         },
                         bottomOffset = paddingValues.calculateBottomPadding(),
-                        onGetErrorMessage = { lineId -> viewModel.getLineErrorMessage(fileId, lineId, effectiveRationalMode) }
+                        onGetErrorMessage = { lineId -> viewModel.getLineErrorMessage(fileId, lineId, effectiveRationalMode) },
+                        isSelected = selectedIndices.contains(index),
+                        isInSelectionMode = isInSelectionMode,
+                        onTapLineNumber = {
+                            handleSelectionTap(index)
+                        },
+                        onTapRow = {
+                            handleSelectionTap(index)
+                        },
+                        onPasteLines = { cursorPos, firstChunk, middleLines, lastChunk ->
+                            coroutineScope.launch {
+                                val lastInsertedId = viewModel.pasteLines(
+                                    line.id,
+                                    cursorPos,
+                                    firstChunk,
+                                    middleLines,
+                                    lastChunk,
+                                    effectiveRationalMode
+                                )
+                                if (lastInsertedId != -1L) {
+                                    focusLineId = lastInsertedId
+                                    // Set focus/cursor at the end of the last clipboard chunk (or beginning of suffix)
+                                    focusCursorPosition = lastChunk.length
+                                    pendingScrollLineId = lastInsertedId
+                                }
+                            }
+                        }
                     )
                     if (index < lines.size - 1) {
                         HorizontalDivider(
@@ -1443,11 +1585,17 @@ private fun LineRow(
     onNavigateDown: () -> Unit,
     onCopyResult: (String) -> Unit,
     bottomOffset: Dp = 0.dp,
-    onGetErrorMessage: suspend (Long) -> String? = { null }
+    onGetErrorMessage: suspend (Long) -> String? = { null },
+    isSelected: Boolean,
+    isInSelectionMode: Boolean,
+    onTapLineNumber: () -> Unit,
+    onTapRow: () -> Unit,
+    onPasteLines: (Int, String, List<String>, String) -> Unit
 ) {
     // Add leading space for backspace detection trick (but not for first line)
     // This allows us to capture backspace even when TextField is at the start of original text
     val displayText = if (lineNumber > 1) " " + line.expression else line.expression
+    val context = LocalContext.current
     val defaultTextColor = MaterialTheme.colorScheme.onSurface
 
     var textFieldValue by remember(line.id) {
@@ -1869,25 +2017,38 @@ private fun LineRow(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .height(IntrinsicSize.Min),
+            .height(IntrinsicSize.Min)
+            .background(if (isSelected) MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.25f) else Color.Transparent)
+            .then(
+                if (isInSelectionMode) {
+                    Modifier.clickable { onTapRow() }
+                } else {
+                    Modifier
+                }
+            ),
         verticalAlignment = Alignment.Top
     ) {
         if (showLineNumbers) {
-            // Line Number Gutter
-            Text(
-                text = lineNumber.toString(),
-                style = MaterialTheme.typography.bodySmall.copy(
-                    fontFamily = FiraCodeFamily,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
-                    fontSize = 12.sp
-                ),
+            // Line Number Gutter (clickable to trigger selection)
+            Box(
                 modifier = Modifier
+                    .clickable { onTapLineNumber() }
                     .padding(start = 8.dp, top = 10.dp)
-                    .width(numberWidth),
-                textAlign = TextAlign.End,
-                softWrap = false,
-                maxLines = 1
-            )
+                    .width(numberWidth)
+            ) {
+                Text(
+                    text = lineNumber.toString(),
+                    style = MaterialTheme.typography.bodySmall.copy(
+                        fontFamily = FiraCodeFamily,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                        fontSize = 12.sp
+                    ),
+                    textAlign = TextAlign.End,
+                    softWrap = false,
+                    maxLines = 1,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
 
             // Spacer for the global vertical divider
             Spacer(modifier = Modifier.width(9.dp)) // 8.dp right padding + 1.dp divider
@@ -1910,15 +2071,41 @@ private fun LineRow(
             Column {
                 BasicTextField(
                     value = textFieldValue,
-                    readOnly = isLocked,
+                    enabled = !isInSelectionMode,
+                    readOnly = isLocked || isInSelectionMode,
                     onValueChange = { newValue ->
-                        if (isLocked) return@BasicTextField
+                        if (isLocked || isInSelectionMode) return@BasicTextField
                         val filteredText = newValue.text.replace("\n", "")
 
-                        // Handle Enter key (Line Splitting)
+                        // Handle Enter key (Line Splitting) / Multi-line Paste
                         // Using indexOf('\n') is more reliable than selection.start because
                         // selection.start can jump ahead after character insertion.
                         if (newValue.text.contains("\n")) {
+                            val addedLength = newValue.text.length - textFieldValue.text.length
+                            if (addedLength > 1) {
+                                // Multi-line Clipboard Paste Interception
+                                val clipboard = context.getSystemService(android.content.Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
+                                val pastedText = clipboard.primaryClip?.getItemAt(0)?.text?.toString() ?: ""
+                                if (pastedText.contains("\n")) {
+                                    val pastedLines = pastedText.split(Regex("\\r?\\n"))
+                                    if (pastedLines.size > 1) {
+                                        val cursorPos = textFieldValue.selection.start
+                                        val cursorPosInExpr = if (lineNumber > 1) {
+                                            (cursorPos - 1).coerceAtLeast(0)
+                                        } else {
+                                            cursorPos
+                                        }
+                                        val firstChunk = pastedLines.first()
+                                        val middleLines = pastedLines.subList(1, pastedLines.size - 1)
+                                        val lastChunk = pastedLines.last()
+
+                                        onPasteLines(cursorPosInExpr, firstChunk, middleLines, lastChunk)
+                                        return@BasicTextField
+                                    }
+                                }
+                            }
+
+                            // Single Enter splitting
                             val splitIndexInTransformed = newValue.text.indexOf('\n')
                             val actualText = newValue.text.replace("\n", "")
                             val normalizedText = if (lineNumber > 1) actualText.removePrefix(" ") else actualText
@@ -2139,23 +2326,27 @@ private fun LineRow(
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.End,
-                modifier = (if (isError) {
-                    Modifier
-                        .clickable {
-                            showTooltip = !showTooltip
-                            if (!showTooltip) {
-                                errorMessage = null
+                modifier = if (isInSelectionMode) {
+                    Modifier.fillMaxSize()
+                } else {
+                    (if (isError) {
+                        Modifier
+                            .clickable {
+                                showTooltip = !showTooltip
+                                if (!showTooltip) {
+                                    errorMessage = null
+                                }
+                            }
+                    } else {
+                        Modifier.clickable {
+                            if (line.result.isNotEmpty()) {
+                                // Copying always uses the standard rounded version without ellipsis
+                                onCopyResult(formatResult(line.result, precision, regionCode, groupingSeparatorEnabled, showEllipsis = false))
+                                showCopiedTooltip = true
                             }
                         }
-                } else {
-                    Modifier.clickable {
-                        if (line.result.isNotEmpty()) {
-                            // Copying always uses the standard rounded version without ellipsis
-                            onCopyResult(formatResult(line.result, precision, regionCode, groupingSeparatorEnabled, showEllipsis = false))
-                            showCopiedTooltip = true
-                        }
-                    }
-                }).fillMaxSize()
+                    }).fillMaxSize()
+                }
             ) {
                 Row(
                     verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorViewModel.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorViewModel.kt
@@ -1098,6 +1098,81 @@ class CalculatorViewModel(
     }
 
     /**
+     * Pastes multi-line clipboard content into the document at [lineId].
+     *
+     * 1. Updates the current line: text-before-cursor + [firstChunk].
+     * 2. Inserts each of [middleLines] as whole new LineEntity rows after it.
+     * 3. Inserts a final line: [lastChunk] + text-after-cursor from the original line.
+     *
+     * Wrapped in a single [saveStateForUndo] call → one Undo step reverts everything.
+     *
+     * @return ID of the last inserted line (used to focus/scroll), or -1 on failure.
+     */
+    suspend fun pasteLines(
+        lineId: Long,
+        cursorPosInExpr: Int,
+        firstChunk: String,
+        middleLines: List<String>,
+        lastChunk: String,
+        rationalMode: Boolean? = null
+    ): Long {
+        return withContext(ioDispatcher) {
+            calculationMutex.withLock {
+                val line   = dao.getLineById(lineId) ?: return@withLock -1L
+                val fileId = line.fileId
+                if (isFileLocked(fileId)) return@withLock -1L
+                saveStateForUndo(fileId)
+
+                val safePos = cursorPosInExpr.coerceIn(0, line.expression.length)
+                val before  = line.expression.substring(0, safePos)
+                val after   = line.expression.substring(safePos)
+
+                // 1. Update current line
+                dao.updateLine(line.copy(
+                    expression = before + firstChunk,
+                    result = "",
+                    version = line.version + 1
+                ))
+
+                // 2. Insert middle lines in order
+                var prevId = line.id
+                for (midExpr in middleLines) {
+                    val newLine = LineEntity(
+                        fileId = fileId,
+                        sortOrder = 0,       // DAO normalizes order
+                        expression = midExpr,
+                        result = ""
+                    )
+                    prevId = dao.moveAndInsertLine(fileId, prevId, newLine)
+                }
+
+                // 3. Insert final line: last clipboard chunk + original suffix
+                val finalId = dao.moveAndInsertLine(
+                    fileId,
+                    prevId,
+                    LineEntity(fileId = fileId, sortOrder = 0, expression = lastChunk + after, result = "")
+                )
+
+                // 4. Recalculate from the modified line downward
+                val updatedLines = dao.getLinesForFileSync(fileId)
+                val startIndex   = updatedLines.indexOfFirst { it.id == line.id }.coerceAtLeast(0)
+                val effectiveRationalMode = rationalMode ?: _rationalMode.value
+                val effectiveDateFormat   = getResolvedDateFormat()
+                val affected = MathEngine.calculateFrom(
+                    updatedLines, startIndex,
+                    createFileContextLoader(fileId, effectiveRationalMode, effectiveDateFormat),
+                    rationalMode = effectiveRationalMode,
+                    dateFormat   = effectiveDateFormat
+                )
+                dao.updateLines(fileId, affected.map { it.copy(version = it.version + 1) },
+                    updateTimestamp = false)
+
+                finalId
+            }
+        }
+    }
+
+    /**
      * Merges [currentLineId] into [prevLineId].
      * The expression of [currentLineId] is appended to [prevLineId], and [currentLineId] is then deleted.
      */

--- a/app/src/test/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorViewModelTest.kt
+++ b/app/src/test/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorViewModelTest.kt
@@ -1,8 +1,8 @@
 package com.vishaltelangre.nerdcalci.ui.calculator
 
-import android.util.Log
 import android.content.Context
 import android.content.SharedPreferences
+import android.util.Log
 import com.vishaltelangre.nerdcalci.data.local.FakeCalculatorDao
 import com.vishaltelangre.nerdcalci.data.local.entities.FileEntity
 import com.vishaltelangre.nerdcalci.data.local.entities.LineEntity
@@ -22,7 +22,7 @@ import org.junit.rules.TestWatcher
 import org.junit.runner.Description
 
 class MainDispatcherRule(
-    val testDispatcher: TestDispatcher = UnconfinedTestDispatcher(TestCoroutineScheduler())
+        val testDispatcher: TestDispatcher = UnconfinedTestDispatcher(TestCoroutineScheduler())
 ) : TestWatcher() {
     override fun starting(description: Description) {
         Dispatchers.setMain(testDispatcher)
@@ -35,8 +35,7 @@ class MainDispatcherRule(
 
 class CalculatorViewModelTest {
 
-    @get:Rule
-    val mainDispatcherRule = MainDispatcherRule()
+    @get:Rule val mainDispatcherRule = MainDispatcherRule()
 
     private lateinit var viewModel: CalculatorViewModel
     private lateinit var fakeDao: FakeCalculatorDao
@@ -72,7 +71,14 @@ class CalculatorViewModelTest {
     @Test
     fun `splitLine split in middle of expression`() = runTest {
         fakeDao.insertFile(FileEntity(id = 1L, name = "TestFile"))
-        val line = LineEntity(id = 1L, fileId = 1L, expression = "a = 10 + 20", result = "30.0", sortOrder = 0)
+        val line =
+                LineEntity(
+                        id = 1L,
+                        fileId = 1L,
+                        expression = "a = 10 + 20",
+                        result = "30.0",
+                        sortOrder = 0
+                )
         fakeDao.insertLine(line)
 
         viewModel.splitLine(1L, 7)
@@ -88,14 +94,14 @@ class CalculatorViewModelTest {
         // Given a temporary scratchpad
         val tempFile = FileEntity(id = 10L, name = "Temp", isTemporary = true)
         fakeDao.insertFile(tempFile)
-        fakeDao.insertLine(LineEntity(fileId = 10L, expression = "1+1", result = "2", sortOrder = 0))
+        fakeDao.insertLine(
+                LineEntity(fileId = 10L, expression = "1+1", result = "2", sortOrder = 0)
+        )
 
         // When duplicating it
         val capturedNewId = CompletableDeferred<Long?>()
-        viewModel.duplicateFile(mockContext, 10L) { newId ->
-            capturedNewId.complete(newId)
-        }
-        
+        viewModel.duplicateFile(mockContext, 10L) { newId -> capturedNewId.complete(newId) }
+
         // Wait for coroutines
         val newId = capturedNewId.await()
         assertNotNull("New ID should not be null", newId)
@@ -112,17 +118,17 @@ class CalculatorViewModelTest {
         val existingTempFile = FileEntity(id = 20L, name = "Scratchpad", isTemporary = true)
         fakeDao.insertFile(existingTempFile)
         fakeDao.insertLine(LineEntity(id = 100L, fileId = 20L, expression = "1+1", sortOrder = 0))
-        
+
         // When a new ViewModel is initialized (it calls ensureScratchpadExists in init)
         val newViewModel = CalculatorViewModel(fakeDao)
-        
+
         // Wait for coroutines in init to finish
         testScheduler.advanceUntilIdle()
-        
+
         // Find the temporary file
         val currentTempFile = fakeDao.files.find { it.isTemporary }
         assertNotNull("Should have a temporary file", currentTempFile)
-        
+
         val lines = fakeDao.getLinesForFileSync(currentTempFile!!.id)
         // Should only have one empty line now (reset/cleared)
         assertEquals("Should have exactly 1 line", 1, lines.size)
@@ -165,9 +171,30 @@ class CalculatorViewModelTest {
 
         val suggestions = viewModel.getSuggestionsForFile("Dates")
 
-        assertTrue(suggestions.contains(com.vishaltelangre.nerdcalci.utils.Suggestion("today", SuggestionType.KEYWORD)))
-        assertTrue(suggestions.contains(com.vishaltelangre.nerdcalci.utils.Suggestion("between", SuggestionType.KEYWORD)))
-        assertTrue(suggestions.contains(com.vishaltelangre.nerdcalci.utils.Suggestion("tomorrow", SuggestionType.KEYWORD)))
+        assertTrue(
+                suggestions.contains(
+                        com.vishaltelangre.nerdcalci.utils.Suggestion(
+                                "today",
+                                SuggestionType.KEYWORD
+                        )
+                )
+        )
+        assertTrue(
+                suggestions.contains(
+                        com.vishaltelangre.nerdcalci.utils.Suggestion(
+                                "between",
+                                SuggestionType.KEYWORD
+                        )
+                )
+        )
+        assertTrue(
+                suggestions.contains(
+                        com.vishaltelangre.nerdcalci.utils.Suggestion(
+                                "tomorrow",
+                                SuggestionType.KEYWORD
+                        )
+                )
+        )
     }
 
     @Test
@@ -182,5 +209,35 @@ class CalculatorViewModelTest {
 
         // Then: lastSyncAt should reflect the stored timestamp
         assertEquals(expectedTimestamp, testViewModel.lastSyncAt.value)
+    }
+
+    @Test
+    fun `pasteLines inserts multi-line paste atomically`() = runTest {
+        fakeDao.insertFile(FileEntity(id = 1L, name = "TestFile"))
+        val line =
+                LineEntity(id = 10L, fileId = 1L, expression = "1 + ", result = "", sortOrder = 0)
+        fakeDao.insertLine(line)
+
+        val firstChunk = "2"
+        val middleLines = listOf("3 + 3", "4 + 4")
+        val lastChunk = "5"
+
+        val lastInsertedId =
+                viewModel.pasteLines(
+                        lineId = 10L,
+                        cursorPosInExpr = 4, // end of "1 + "
+                        firstChunk = firstChunk,
+                        middleLines = middleLines,
+                        lastChunk = lastChunk,
+                        rationalMode = false
+                )
+
+        val lines = fakeDao.getLinesForFileSync(1L)
+        assertEquals(4, lines.size)
+        assertEquals("1 + 2", lines[0].expression)
+        assertEquals("3 + 3", lines[1].expression)
+        assertEquals("4 + 4", lines[2].expression)
+        assertEquals("5", lines[3].expression)
+        assertEquals(lastInsertedId, lines[3].id)
     }
 }

--- a/fastlane/metadata/android/en-US/changelogs/470.txt
+++ b/fastlane/metadata/android/en-US/changelogs/470.txt
@@ -1,0 +1,2 @@
+- Added ability to select multiple lines for copying either by tapping on line number or using "Select lines..." menu (Issue #75).
+- Added multi-line paste support (Issue #75).


### PR DESCRIPTION
### What

- Fixes #75.

### Screenshots

Tapping on line numbers would select the lines.

<img width="300" alt="Image" src="https://github.com/user-attachments/assets/42ab5655-791d-4d0c-a30c-ae5a7318f7d6" />

If the line numbers are not shown, one can enable the line selection mode using "⋮ → Select lines" menu item.

<img width="300" alt="Image" src="https://github.com/user-attachments/assets/d807eb84-6831-40e1-9b27-fb331b3ecb1d" />

video demo

https://github.com/user-attachments/assets/5294cba0-d4f4-49dd-a624-3f6e8ea4d9bf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes – Version 4.7.0

* **New Features**
  * Multi-line selection: Select multiple calculation lines by tapping line numbers or using the "Select lines..." menu to copy them together
  * Multi-line paste support: Paste multi-line content directly into your calculations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vishaltelangre/NerdCalci/pull/192?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->