### PR TITLE
Add multiplication rules for POWER×TIME → ENERGY unit derivation

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -880,12 +880,41 @@ cos(60 degree) # 0.5
 | Kilocalorie                | `kCal`, `kcal`, `kilocalorie`, `kilocalories`                                         | `10 kCal`   |
 | Watt hour                  | `Wh`, `watt hour`, `watt hours`                                                       | `10 Wh`     |
 | Kilowatt hour              | `kWh`, `kilowatt hour`, `kilowatt hours`                                              | `10 kWh`    |
+| Milliwatt hour             | `mWh`, `milliwatt hour`, `milliwatt hours`                                            | `10 mWh`    |
+| Megawatt hour              | `MWh`, `megawatt hour`, `megawatt hours`                                              | `10 MWh`    |
+| Gigawatt hour              | `GWh`, `gigawatt hour`, `gigawatt hours`                                              | `10 GWh`    |
+| Terawatt hour              | `TWh`, `terawatt hour`, `terawatt hours`                                              | `10 TWh`    |
+| Watt second                | `Ws`, `watt second`, `watt seconds`                                                   | `10 Ws`     |
+| Milliwatt second           | `mWs`, `milliwatt second`, `milliwatt seconds`                                        | `10 mWs`    |
+| Kilowatt second            | `kWs`, `kilowatt second`, `kilowatt seconds`                                          | `10 kWs`    |
+| Megawatt second            | `MWs`, `megawatt second`, `megawatt seconds`                                          | `10 MWs`    |
+| Gigawatt second            | `GWs`, `gigawatt second`, `gigawatt seconds`                                          | `10 GWs`    |
+| Terawatt second            | `TWs`, `terawatt second`, `terawatt seconds`                                          | `10 TWs`    |
+| Watt minute                | `Wmin`, `watt minute`, `watt minutes`                                                 | `10 Wmin`   |
+| Milliwatt minute           | `mWmin`, `mWm`, `milliwatt minute`, `milliwatt minutes`                               | `10 mWmin`  |
+| Kilowatt minute            | `kWmin`, `kWm`, `kilowatt minute`, `kilowatt minutes`                                 | `10 kWmin`  |
+| Megawatt minute            | `MWmin`, `MWm`, `megawatt minute`, `megawatt minutes`                                 | `10 MWmin`  |
+| Gigawatt minute            | `GWmin`, `GWm`, `gigawatt minute`, `gigawatt minutes`                                 | `10 GWmin`  |
+| Terawatt minute            | `TWmin`, `TWm`, `terawatt minute`, `terawatt minutes`                                 | `10 TWmin`  |
 | Electron volt              | `eV`, `electronvolt`, `electron volts`                                                | `10 eV`     |
 | Foot pound-force           | `ft_lbf`, `foot_pound`                                                                | `10 ft_lbf` |
 | British thermal unit       | `BTU`, `btu`                                                                          | `10 BTU`    |
 | Tons of TNT equivalent     | `tTNT`, `ton of TNT`, `tons of TNT`, `tonne of TNT`, `tonnes of TNT`                  | `10 tTNT`   |
 | Kilotons of TNT equivalent | `ktTNT`, `kiloton of TNT`, `kilotons of TNT`, `kilotonne of TNT`, `kilotonnes of TNT` | `10 ktTNT`  |
 | Megatons of TNT equivalent | `MtTNT`, `megaton of TNT`, `megatons of TNT`, `megatonne of TNT`, `megatonnes of TNT` | `10 MtTNT`  |
+
+Dimension-safe power/energy arithmetic is supported:
+- `W * h` results in `Wh`
+- `kW * h` results in `kWh`
+- `W * s` results in `J`
+- `kW * s` results in `kWs`
+- `W * min` results in `Wmin`
+- `Wh / h` results in `W`
+- `kWh / h` results in `kW`
+- `Wh / W` results in `h`
+- `kWh / kW` results in `h`
+- `J / W` results in `s`
+- `J / s` results in `W`
 
 ### Power
 

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/UnitConverter.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/UnitConverter.kt
@@ -69,7 +69,9 @@ object UnitConverter {
         UnitRule(UnitCategory.ELECTRIC_POTENTIAL, UnitCategory.ELECTRIC_CURRENT, result = { _, _ -> "W" }),
         UnitRule(UnitCategory.ELECTRIC_CURRENT, UnitCategory.ELECTRIC_POTENTIAL, result = { _, _ -> "W" }),
         UnitRule(UnitCategory.ELECTRIC_CURRENT, UnitCategory.TIME, result = { left, right -> matchCurrentTimeToCharge(left, right) }),
-        UnitRule(UnitCategory.TIME, UnitCategory.ELECTRIC_CURRENT, result = { left, right -> matchCurrentTimeToCharge(right, left) })
+        UnitRule(UnitCategory.TIME, UnitCategory.ELECTRIC_CURRENT, result = { left, right -> matchCurrentTimeToCharge(right, left) }),
+        UnitRule(UnitCategory.POWER, UnitCategory.TIME, result = { left, right -> matchPowerTimeToEnergy(left, right) }),
+        UnitRule(UnitCategory.TIME, UnitCategory.POWER, result = { left, right -> matchPowerTimeToEnergy(right, left) })
     )
 
     // Division rules are explicit, reversible, and keep same-category cancellation separate.
@@ -153,6 +155,12 @@ object UnitConverter {
         }),
         UnitRule(UnitCategory.LENGTH, UnitCategory.SPEED, result = { left, right ->
             matchSpeedToTime(right.symbols[0])
+        }),
+        UnitRule(UnitCategory.ENERGY, UnitCategory.TIME, result = { left, right ->
+            matchEnergyTimeToPower(left, right)
+        }),
+        UnitRule(UnitCategory.ENERGY, UnitCategory.POWER, result = { left, right ->
+            matchEnergyPowerToTime(left, right)
         })
     )
 
@@ -354,6 +362,22 @@ object UnitConverter {
         Unit("Tons of TNT equivalent", listOf("tTNT", "ton of TNT", "tons of TNT", "tonne of TNT", "tonnes of TNT"), UnitCategory.ENERGY, BigDecimal("4.184e9")),
         Unit("Kilotons of TNT equivalent", listOf("ktTNT", "kiloton of TNT", "kilotons of TNT", "kilotonne of TNT", "kilotonnes of TNT"), UnitCategory.ENERGY, BigDecimal("4.184e12")),
         Unit("Megatons of TNT equivalent", listOf("MtTNT", "megaton of TNT", "megatons of TNT", "megatonne of TNT", "megatonnes of TNT"), UnitCategory.ENERGY, BigDecimal("4.184e15")),
+        Unit("Watt second", listOf("Ws", "watt second", "watt seconds"), UnitCategory.ENERGY, BigDecimal.ONE),
+        Unit("Watt minute", listOf("Wmin", "watt minute", "watt minutes"), UnitCategory.ENERGY, BigDecimal("60.0")),
+        Unit("Milliwatt hour", listOf("mWh", "milliwatt hour", "milliwatt hours"), UnitCategory.ENERGY, BigDecimal("3.6")),
+        Unit("Megawatt hour", listOf("MWh", "megawatt hour", "megawatt hours"), UnitCategory.ENERGY, BigDecimal("3.6e9")),
+        Unit("Gigawatt hour", listOf("GWh", "gigawatt hour", "gigawatt hours"), UnitCategory.ENERGY, BigDecimal("3.6e12")),
+        Unit("Terawatt hour", listOf("TWh", "terawatt hour", "terawatt hours"), UnitCategory.ENERGY, BigDecimal("3.6e15")),
+        Unit("Kilowatt second", listOf("kWs", "kilowatt second", "kilowatt seconds"), UnitCategory.ENERGY, BigDecimal("1000.0")),
+        Unit("Megawatt second", listOf("MWs", "megawatt second", "megawatt seconds"), UnitCategory.ENERGY, BigDecimal("1e6")),
+        Unit("Gigawatt second", listOf("GWs", "gigawatt second", "gigawatt seconds"), UnitCategory.ENERGY, BigDecimal("1e9")),
+        Unit("Terawatt second", listOf("TWs", "terawatt second", "terawatt seconds"), UnitCategory.ENERGY, BigDecimal("1e12")),
+        Unit("Milliwatt second", listOf("mWs", "milliwatt second", "milliwatt seconds"), UnitCategory.ENERGY, BigDecimal("0.001")),
+        Unit("Kilowatt minute", listOf("kWmin", "kWm", "kilowatt minute", "kilowatt minutes"), UnitCategory.ENERGY, BigDecimal("60000.0")),
+        Unit("Megawatt minute", listOf("MWmin", "MWm", "megawatt minute", "megawatt minutes"), UnitCategory.ENERGY, BigDecimal("6e7")),
+        Unit("Gigawatt minute", listOf("GWmin", "GWm", "gigawatt minute", "gigawatt minutes"), UnitCategory.ENERGY, BigDecimal("6e10")),
+        Unit("Terawatt minute", listOf("TWmin", "TWm", "terawatt minute", "terawatt minutes"), UnitCategory.ENERGY, BigDecimal("6e13")),
+        Unit("Milliwatt minute", listOf("mWmin", "mWm", "milliwatt minute", "milliwatt minutes"), UnitCategory.ENERGY, BigDecimal("0.06")),
 
         // --- POWER --- (Base: Watt)
         Unit("Watt", listOf("W", "watt", "watts"), UnitCategory.POWER, BigDecimal.ONE),
@@ -874,6 +898,15 @@ object UnitConverter {
         "G" to "G"
     )
 
+    private val POWER_PREFIX_MAP = mapOf(
+        "" to "",
+        "m" to "m",
+        "k" to "k",
+        "M" to "M",
+        "G" to "G",
+        "T" to "T"
+    )
+
     private fun matchCurrentTimeToCharge(current: Unit, time: Unit): String? {
         val currentSym = current.symbols.first()
         val timeSym = time.symbols.first()
@@ -886,6 +919,61 @@ object UnitConverter {
             "s" -> prefix + "As"
             "min" -> prefix + "Amin"
             "h" -> prefix + "Ah"
+            else -> null
+        }
+    }
+
+    private fun matchPowerTimeToEnergy(power: Unit, time: Unit): String? {
+        val powerSym = power.symbols.first()
+        val timeSym = time.symbols.first()
+
+        if (!powerSym.endsWith("W")) return null
+        val prefixRaw = powerSym.removeSuffix("W")
+        val prefix = POWER_PREFIX_MAP[prefixRaw] ?: return null
+
+        val candidate = when (timeSym) {
+            "s" -> if (prefix == "") "J" else prefix + "Ws"
+            "min" -> prefix + "Wmin"
+            "h" -> prefix + "Wh"
+            else -> null
+        }
+        return if (candidate != null && findUnit(candidate) != null) candidate else null
+    }
+
+    private fun matchEnergyTimeToPower(energy: Unit, time: Unit): String? {
+        val energySym = energy.symbols.first()
+        val timeSym = time.symbols.first()
+
+        return when {
+            energySym == "J" && timeSym == "s" -> "W"
+            energySym.endsWith("Wh") && timeSym == "h" -> {
+                val prefix = energySym.removeSuffix("Wh")
+                if (prefix.isEmpty() || prefix in POWER_PREFIX_MAP) prefix + "W" else null
+            }
+            energySym.endsWith("Wmin") && timeSym == "min" -> {
+                val prefix = energySym.removeSuffix("Wmin")
+                if (prefix.isEmpty() || prefix in POWER_PREFIX_MAP) prefix + "W" else null
+            }
+            energySym.endsWith("Ws") && timeSym == "s" -> {
+                val prefix = energySym.removeSuffix("Ws")
+                if (prefix.isEmpty() || prefix in POWER_PREFIX_MAP) prefix + "W" else null
+            }
+            else -> null
+        }
+    }
+
+    private fun matchEnergyPowerToTime(energy: Unit, power: Unit): String? {
+        val energySym = energy.symbols.first()
+        val powerSym = power.symbols.first()
+
+        if (!powerSym.endsWith("W")) return null
+        val powerPrefix = POWER_PREFIX_MAP[powerSym.removeSuffix("W")] ?: return null
+
+        return when {
+            energySym == powerPrefix + "Wh" -> "h"
+            energySym == powerPrefix + "Wmin" -> "min"
+            energySym == powerPrefix + "Ws" -> "s"
+            energySym == "J" && powerPrefix == "" -> "s"
             else -> null
         }
     }

--- a/app/src/test/java/com/vishaltelangre/nerdcalci/core/ElectricalUnitConversionTest.kt
+++ b/app/src/test/java/com/vishaltelangre/nerdcalci/core/ElectricalUnitConversionTest.kt
@@ -116,4 +116,104 @@ class ElectricalUnitConversionTest {
         val flow3Base = UnitConverter.toBase(BigDecimal("60"), mAmin, emptyMap())
         assertEquals(1.0, UnitConverter.fromBase(flow3Base, mAh, emptyMap()).toDouble(), 0.001)
     }
+
+    @Test
+    fun `W times h results in Wh`() {
+        val watt = UnitConverter.findUnit("W")!!
+        val hour = UnitConverter.findUnit("h")!!
+        assertEquals("Wh", UnitConverter.deriveUnit(watt, hour, TokenKind.STAR))
+        assertEquals("Wh", UnitConverter.deriveUnit(hour, watt, TokenKind.STAR))
+
+        val w = BigDecimal("12")
+        val h = BigDecimal("5")
+        val resultBase = UnitConverter.toBase(w, watt, emptyMap()) * UnitConverter.toBase(h, hour, emptyMap())
+        val wh = UnitConverter.findUnit("Wh")!!
+        val resultValue = UnitConverter.fromBase(resultBase, wh, emptyMap())
+        assertEquals(60.0, resultValue.toDouble(), 0.001)
+    }
+
+    @Test
+    fun `kW times h results in kWh`() {
+        val kW = UnitConverter.findUnit("kW")!!
+        val hour = UnitConverter.findUnit("h")!!
+        assertEquals("kWh", UnitConverter.deriveUnit(kW, hour, TokenKind.STAR))
+        assertEquals("kWh", UnitConverter.deriveUnit(hour, kW, TokenKind.STAR))
+
+        val kw = BigDecimal("3")
+        val h = BigDecimal("2")
+        val resultBase = UnitConverter.toBase(kw, kW, emptyMap()) * UnitConverter.toBase(h, hour, emptyMap())
+        val kwh = UnitConverter.findUnit("kWh")!!
+        val resultValue = UnitConverter.fromBase(resultBase, kwh, emptyMap())
+        assertEquals(6.0, resultValue.toDouble(), 0.001)
+    }
+
+    @Test
+    fun `W times s results in J`() {
+        val watt = UnitConverter.findUnit("W")!!
+        val sec = UnitConverter.findUnit("s")!!
+        assertEquals("J", UnitConverter.deriveUnit(watt, sec, TokenKind.STAR))
+
+        val w = BigDecimal("100")
+        val s = BigDecimal("30")
+        val resultBase = UnitConverter.toBase(w, watt, emptyMap()) * UnitConverter.toBase(s, sec, emptyMap())
+        val joule = UnitConverter.findUnit("J")!!
+        val resultValue = UnitConverter.fromBase(resultBase, joule, emptyMap())
+        assertEquals(3000.0, resultValue.toDouble(), 0.001)
+    }
+
+    @Test
+    fun `Wh divided by h results in W`() {
+        val wh = UnitConverter.findUnit("Wh")!!
+        val h = UnitConverter.findUnit("h")!!
+        assertEquals("W", UnitConverter.deriveUnit(wh, h, TokenKind.SLASH))
+
+        val whVal = BigDecimal("60")
+        val hVal = BigDecimal("5")
+        val resultBase = UnitConverter.toBase(whVal, wh, emptyMap()).divide(UnitConverter.toBase(hVal, h, emptyMap()), java.math.MathContext.DECIMAL128)
+        val watt = UnitConverter.findUnit("W")!!
+        val resultValue = UnitConverter.fromBase(resultBase, watt, emptyMap())
+        assertEquals(12.0, resultValue.toDouble(), 0.001)
+    }
+
+    @Test
+    fun `kWh divided by h results in kW`() {
+        val kwh = UnitConverter.findUnit("kWh")!!
+        val h = UnitConverter.findUnit("h")!!
+        assertEquals("kW", UnitConverter.deriveUnit(kwh, h, TokenKind.SLASH))
+
+        val kwhVal = BigDecimal("6")
+        val hVal = BigDecimal("2")
+        val resultBase = UnitConverter.toBase(kwhVal, kwh, emptyMap()).divide(UnitConverter.toBase(hVal, h, emptyMap()), java.math.MathContext.DECIMAL128)
+        val kw = UnitConverter.findUnit("kW")!!
+        val resultValue = UnitConverter.fromBase(resultBase, kw, emptyMap())
+        assertEquals(3.0, resultValue.toDouble(), 0.001)
+    }
+
+    @Test
+    fun `Wh divided by W results in h`() {
+        val wh = UnitConverter.findUnit("Wh")!!
+        val watt = UnitConverter.findUnit("W")!!
+        assertEquals("h", UnitConverter.deriveUnit(wh, watt, TokenKind.SLASH))
+
+        val whVal = BigDecimal("60")
+        val wVal = BigDecimal("12")
+        val resultBase = UnitConverter.toBase(whVal, wh, emptyMap()).divide(UnitConverter.toBase(wVal, watt, emptyMap()), java.math.MathContext.DECIMAL128)
+        val hour = UnitConverter.findUnit("h")!!
+        val resultValue = UnitConverter.fromBase(resultBase, hour, emptyMap())
+        assertEquals(5.0, resultValue.toDouble(), 0.001)
+    }
+
+    @Test
+    fun `J divided by W results in s`() {
+        val joule = UnitConverter.findUnit("J")!!
+        val watt = UnitConverter.findUnit("W")!!
+        assertEquals("s", UnitConverter.deriveUnit(joule, watt, TokenKind.SLASH))
+
+        val jVal = BigDecimal("3000")
+        val wVal = BigDecimal("100")
+        val resultBase = UnitConverter.toBase(jVal, joule, emptyMap()).divide(UnitConverter.toBase(wVal, watt, emptyMap()), java.math.MathContext.DECIMAL128)
+        val sec = UnitConverter.findUnit("s")!!
+        val resultValue = UnitConverter.fromBase(resultBase, sec, emptyMap())
+        assertEquals(30.0, resultValue.toDouble(), 0.001)
+    }
 }

--- a/app/src/test/java/com/vishaltelangre/nerdcalci/core/MixedUnitUsageTest.kt
+++ b/app/src/test/java/com/vishaltelangre/nerdcalci/core/MixedUnitUsageTest.kt
@@ -465,4 +465,143 @@ class MixedUnitUsageTest {
             }
         }
     }
+
+    @Test
+    fun `multiply power by time yields energy`() {
+        testCalculate(
+            "12 W * 5 h",
+            "5 h * 12 W",
+            "3 kW * 2 h",
+            "2 h * 3 kW",
+            "100 W * 30 s",
+            "30 s * 100 W",
+            "5 W * 10 min",
+            "10 min * 5 W"
+        ) { result ->
+            assertEquals("60.0 Wh", result[0].result)
+            assertEquals("60.0 Wh", result[1].result)
+            assertEquals("6.0 kWh", result[2].result)
+            assertEquals("6.0 kWh", result[3].result)
+            assertEquals("3000.0 J", result[4].result)
+            assertEquals("3000.0 J", result[5].result)
+            assertEquals("50.0 Wmin", result[6].result)
+            assertEquals("50.0 Wmin", result[7].result)
+        }
+    }
+
+    @Test
+    fun `divide energy by time yields power`() {
+        testCalculate(
+            "60 Wh / 5 h",
+            "6 kWh / 2 h",
+            "3000 J / 30 s"
+        ) { result ->
+            assertEquals("12.0 W", result[0].result)
+            assertEquals("3.0 kW", result[1].result)
+            assertEquals("100.0 W", result[2].result)
+        }
+    }
+
+    @Test
+    fun `divide energy by power yields time`() {
+        testCalculate(
+            "60 Wh / 12 W",
+            "6 kWh / 3 kW",
+            "3000 J / 100 W"
+        ) { result ->
+            assertEquals("5.0 h", result[0].result)
+            assertEquals("2.0 h", result[1].result)
+            assertEquals("30.0 s", result[2].result)
+        }
+    }
+
+    @Test
+    fun `prefixed power times second yields prefixed Ws`() {
+        testCalculate(
+            "3 kW * 30 s",
+            "30 s * 3 kW",
+            "2 MW * 5 s",
+            "5 GW * 2 s"
+        ) { result ->
+            assertEquals("90.0 kWs", result[0].result)
+            assertEquals("90.0 kWs", result[1].result)
+            assertEquals("10.0 MWs", result[2].result)
+            assertEquals("10.0 GWs", result[3].result)
+        }
+    }
+
+    @Test
+    fun `prefixed power times minute yields prefixed Wmin`() {
+        testCalculate(
+            "4 kW * 5 min",
+            "5 min * 4 kW",
+            "2 MW * 3 min"
+        ) { result ->
+            assertEquals("20.0 kWmin", result[0].result)
+            assertEquals("20.0 kWmin", result[1].result)
+            assertEquals("6.0 MWmin", result[2].result)
+        }
+    }
+
+    @Test
+    fun `divide prefixed Ws by time or power`() {
+        testCalculate(
+            "90 kWs / 30 s",
+            "90 kWs / 3 kW",
+            "10 MWs / 5 s",
+            "10 MWs / 2 MW"
+        ) { result ->
+            assertEquals("3.0 kW", result[0].result)
+            assertEquals("30.0 s", result[1].result)
+            assertEquals("2.0 MW", result[2].result)
+            assertEquals("5.0 s", result[3].result)
+        }
+    }
+
+    @Test
+    fun `divide plain Wmin and Ws by time or power`() {
+        testCalculate(
+            "50 Wmin / 5 min",
+            "50 Wmin / 10 W",
+            "90 Ws / 30 s",
+            "90 Ws / 9 W"
+        ) { result ->
+            assertEquals("10.0 W", result[0].result)
+            assertEquals("5.0 min", result[1].result)
+            assertEquals("3.0 W", result[2].result)
+            assertEquals("10.0 s", result[3].result)
+        }
+    }
+
+    @Test
+    fun `divide MWh GWh mWh by time or power`() {
+        testCalculate(
+            "10 MWh / 5 h",
+            "10 MWh / 2 MW",
+            "15 GWh / 3 h",
+            "15 GWh / 5 GW",
+            "12 mWh / 4 mW"
+        ) { result ->
+            assertEquals("2.0 MW", result[0].result)
+            assertEquals("5.0 h", result[1].result)
+            assertEquals("5.0 GW", result[2].result)
+            assertEquals("3.0 h", result[3].result)
+            assertEquals("3.0 h", result[4].result)
+        }
+    }
+
+    @Test
+    fun `divide prefixed Wmin by time or power`() {
+        testCalculate(
+            "20 kWmin / 5 min",
+            "20 kWmin / 4 kW",
+            "6 MWmin / 2 min",
+            "6 MWmin / 3 MW"
+        ) { result ->
+            assertEquals("4.0 kW", result[0].result)
+            assertEquals("5.0 min", result[1].result)
+            assertEquals("3.0 MW", result[2].result)
+            assertEquals("2.0 min", result[3].result)
+        }
+    }
 }


### PR DESCRIPTION
For #209

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Added support for deriving and converting energy units from power/time combinations (e.g., Watts × hours = Watt-hours, Watts × seconds = Joules)
* Extended the unit catalog with additional energy units (including Watt-second and Watt-minute variants, plus multi-prefix Watt-hour forms)
* Expanded power/energy/time reduction rules for both operand orders and across SI prefixes (e.g., energy ÷ time → power, energy ÷ power → time)

## Tests
* Added comprehensive unit-derivation and conversion coverage for power/energy/time relationships.

## Documentation
* Updated the reference guide with the new energy units and the documented arithmetic rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->