### PR TITLE
Fix the display bug in date results for the Oct/Dec months of the current year

### DIFF
--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/MathEngine.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/MathEngine.kt
@@ -611,6 +611,21 @@ object MathEngine {
         }
 
         val trimmedUnit = unitStr.trim().lowercase()
+
+        // Guard: if the suffix after the first number looks like a date/duration fragment
+        // rather than a unit abbreviation, return the raw result unchanged.
+        // Date strings (DMY format) have a capitalized month abbreviation ("Oct", "Dec") as the
+        // first token, multi-component durations have internal spaces ("3 wk 5 d"), and
+        // other-year date strings have commas ("Oct, 2025"). None of these patterns can appear
+        // in a valid unit abbreviation, so we can safely bail out here.
+        val trimmedUnitRaw = unitStr.trim()
+        if (trimmedUnitRaw.isNotEmpty() &&
+            (trimmedUnitRaw.first().isUpperCase() ||
+             trimmedUnitRaw.contains(' ') ||
+             trimmedUnitRaw.contains(','))) {
+            return rawResult
+        }
+
         val isNumeralSystem = UnitConverter.isNumeralSystemSymbol(trimmedUnit)
 
         val (formattedResult, isTruncated) = if (isNumeralSystem) {

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/MathEngine.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/MathEngine.kt
@@ -29,6 +29,14 @@ data class MathContext(
 
 object MathEngine {
 
+    // English 3-letter month abbreviations produced by DateEvaluator (TextStyle.SHORT + Locale.ENGLISH).
+    // Used to detect DMY-format date strings in formatDisplayResult without conflating them with
+    // legitimate uppercase unit symbols (K, L, N, Pa, NM, Hz, …).
+    private val MONTH_ABBREVIATIONS = setOf(
+        "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+        "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+    )
+
     /**
      * Registry of dynamic variable keywords.
      *
@@ -614,13 +622,22 @@ object MathEngine {
 
         // Guard: if the suffix after the first number looks like a date/duration fragment
         // rather than a unit abbreviation, return the raw result unchanged.
-        // Date strings (DMY format) have a capitalized month abbreviation ("Oct", "Dec") as the
-        // first token, multi-component durations have internal spaces ("3 wk 5 d"), and
-        // other-year date strings have commas ("Oct, 2025"). None of these patterns can appear
-        // in a valid unit abbreviation, so we can safely bail out here.
+        //
+        // Three cases to detect:
+        // 1. DMY current-year dates: day number + English month abbreviation
+        //    e.g. "1 Oct", "15 Dec" — the month token is always one of the 12 short names
+        //    produced by DateEvaluator (TextStyle.SHORT + Locale.ENGLISH, so first letter
+        //    uppercase, rest lowercase). No real unit symbol matches these case-sensitively.
+        // 2. Multi-component duration strings: internal space after trimming
+        //    e.g. "3 wk 5 d", "2 h 30 min" — unit abbreviations are always a single token.
+        // 3. Other-year date strings: contain a comma
+        //    e.g. "1 Oct, 2025", "15 Dec, 2027".
+        //
+        // Note: the first().isUpperCase() check is intentionally avoided here — many real unit
+        // symbols start with an uppercase letter (K, L, N, J, Pa, NM, AU, Hz, GB, …).
         val trimmedUnitRaw = unitStr.trim()
         if (trimmedUnitRaw.isNotEmpty() &&
-            (trimmedUnitRaw.first().isUpperCase() ||
+            (MONTH_ABBREVIATIONS.contains(trimmedUnitRaw) ||
              trimmedUnitRaw.contains(' ') ||
              trimmedUnitRaw.contains(','))) {
             return rawResult

--- a/app/src/test/java/com/vishaltelangre/nerdcalci/core/MathEngineTest.kt
+++ b/app/src/test/java/com/vishaltelangre/nerdcalci/core/MathEngineTest.kt
@@ -2244,6 +2244,39 @@ class MathEngineTest {
             }
 
     @Test
+    fun `formatDisplayResult passes date strings through unchanged regardless of precision or locale`() =
+        runBlocking {
+            // DMY format, current-year dates: day number followed by capitalized month abbreviation.
+            // "Oct" was being misidentified as the octal numeral system unit ("oct"),
+            // causing "1 Oct" to render as "0o1".
+            assertEquals("1 Oct", MathEngine.formatDisplayResult("1 Oct", Constants.PRECISION_OFF, Locale.GERMANY))
+            assertEquals("1 Oct", MathEngine.formatDisplayResult("1 Oct", 2, Locale.GERMANY))
+            // "Dec" was misidentified as the decimal numeral system unit ("dec"),
+            // causing "1 Dec" to strip the month and render as just "1".
+            assertEquals("1 Dec", MathEngine.formatDisplayResult("1 Dec", Constants.PRECISION_OFF, Locale.GERMANY))
+            assertEquals("1 Dec", MathEngine.formatDisplayResult("1 Dec", 2, Locale.GERMANY))
+            // Other months in DMY current-year format should also be unaffected.
+            assertEquals("1 Nov", MathEngine.formatDisplayResult("1 Nov", Constants.PRECISION_OFF, Locale.GERMANY))
+            assertEquals("15 Mar", MathEngine.formatDisplayResult("15 Mar", Constants.PRECISION_OFF, Locale.GERMANY))
+
+            // Other-year DMY format: "1 Oct, 2025" was rendered as "1,0 Oct, 2025" (or "1.0 Oct,
+            // 2025") because the day number "1" was reformatted as a decimal value.
+            assertEquals("1 Oct, 2025", MathEngine.formatDisplayResult("1 Oct, 2025", Constants.PRECISION_OFF, Locale.GERMANY))
+            assertEquals("1 Oct, 2025", MathEngine.formatDisplayResult("1 Oct, 2025", 2, Locale.GERMANY))
+            assertEquals("1 Dec, 2025", MathEngine.formatDisplayResult("1 Dec, 2025", Constants.PRECISION_OFF, Locale.GERMANY))
+            assertEquals("15 Mar, 2027", MathEngine.formatDisplayResult("15 Mar, 2027", Constants.PRECISION_OFF, Locale.GERMANY))
+
+            // MDY format strings already worked (non-numeric first token); verify they still do.
+            assertEquals("Oct 1", MathEngine.formatDisplayResult("Oct 1", Constants.PRECISION_OFF, Locale.GERMANY))
+            assertEquals("Oct 1, 2025", MathEngine.formatDisplayResult("Oct 1, 2025", Constants.PRECISION_OFF, Locale.GERMANY))
+            assertEquals("Dec 1", MathEngine.formatDisplayResult("Dec 1", Constants.PRECISION_OFF, Locale.GERMANY))
+
+            // Multi-component duration strings should also pass through unchanged.
+            assertEquals("3 wk 5 d", MathEngine.formatDisplayResult("3 wk 5 d", Constants.PRECISION_OFF, Locale.GERMANY))
+            assertEquals("2 h 30 min", MathEngine.formatDisplayResult("2 h 30 min", Constants.PRECISION_OFF, Locale.GERMANY))
+        }
+
+    @Test
     fun `getErrorDetails handles undefined variable`() =
             testCalculate("x + 5") { result ->
                 assertError("Unknown variable `x`", result[0], result, 0)

--- a/app/src/test/java/com/vishaltelangre/nerdcalci/core/MathEngineTest.kt
+++ b/app/src/test/java/com/vishaltelangre/nerdcalci/core/MathEngineTest.kt
@@ -2274,6 +2274,14 @@ class MathEngineTest {
             // Multi-component duration strings should also pass through unchanged.
             assertEquals("3 wk 5 d", MathEngine.formatDisplayResult("3 wk 5 d", Constants.PRECISION_OFF, Locale.GERMANY))
             assertEquals("2 h 30 min", MathEngine.formatDisplayResult("2 h 30 min", Constants.PRECISION_OFF, Locale.GERMANY))
+
+            // Regression: uppercase-first unit symbols (K=Kelvin, L=Liter, Pa=Pascal, NM=Nautical
+            // Mile) must NOT be treated as date strings — they should still receive normal numeric
+            // locale-formatting.
+            assertEquals("300,50 K", MathEngine.formatDisplayResult("300.5 K", 2, Locale.GERMANY))
+            assertEquals("1,23 L", MathEngine.formatDisplayResult("1.234 L", 2, Locale.GERMANY))
+            assertEquals("101.325 Pa", MathEngine.formatDisplayResult("101325.0 Pa", 2, Locale.GERMANY))
+            assertEquals("1,85 NM", MathEngine.formatDisplayResult("1.852 NM", 2, Locale.GERMANY))
         }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/vishaltelangre/NerdCalci/issues/215.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Date-like and multi-part duration results are now passed through unchanged instead of being reformatted or interpreted as unit values.
  * Added safer handling for suffix text (including English month abbreviations) to prevent incorrect display when they resemble unit labels.

* **Tests**
  * Added regression coverage to ensure date/duration strings remain intact across precision settings and locale variations.
  * Added checks preventing month abbreviations from being misclassified as units.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->