### PR TITLE
feat: add min/minimum and max/maximum functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.9.3] - 2026-07-07
+### Added
+- Added `min`/`minimum` and `max`/`maximum` dynamic variables to find the smallest or largest value in the preceding block (Issue: #220).
+
 ## [4.9.2] - 2026-06-25
 ### Added
 - Added support for deriving and converting energy units from power/time combinations (Issue: #209).

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -411,6 +411,38 @@ half_avg = avg / 2  # evaluates to 25
 
 `avg` and `average` are reserved keywords and cannot be reassigned.
 
+### Min / Max
+
+Use `min` (or `minimum`) and `max` (or `maximum`) to find the smallest or largest line result above, up to the nearest blank/comment/error line.
+
+```text
+jan = 100
+feb = 200
+mar = 300
+max                 # evaluates to 300
+```
+
+Blank/comment/error lines create blocks — `min` and `max` only check within the current block:
+
+```text
+a = 10
+b = 20
+max                 # evaluates to 20
+
+c = 5
+min                 # evaluates to 5
+```
+
+Use them inside expressions:
+
+```text
+item1 = 25
+item2 = 75
+diff = max - min    # evaluates to 50
+```
+
+`min`, `minimum`, `max`, and `maximum` are reserved keywords and cannot be reassigned.
+
 ### Reference to previous line result
 
 Use `last`, `prev`, `previous`, `above`, or `_` to reference the result of the immediately preceding line.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
     defaultConfig {
         applicationId = "com.vishaltelangre.nerdcalci"
         minSdk = 23
-        versionCode = 492
-        versionName = "4.9.2"
+        versionCode = 493
+        versionName = "4.9.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/MathEngine.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/MathEngine.kt
@@ -443,7 +443,7 @@ object MathEngine {
             }
         }
 
-        var maxValue = BigDecimal.ZERO
+        var maxValue: BigDecimal? = null
         for (result in blockResults) {
             val resultValue = result.value ?: BigDecimal.ZERO
             val resultUnit = result.unit?.let { UnitConverter.findUnit(it) }
@@ -467,7 +467,7 @@ object MathEngine {
                 }
             }
 
-            if (resultValue > maxValue)
+            if (maxValue == null || resultValue > maxValue)
                 maxValue = resultValue
         }
 

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/MathEngine.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/MathEngine.kt
@@ -53,6 +53,12 @@ object MathEngine {
         "avg"               to { results, _ -> computeBlockAverage(results) },
         "average"           to { results, _ -> computeBlockAverage(results) },
 
+        "min"               to { results, _ -> computeBlockMin(results) },
+        "minimum"           to { results, _ -> computeBlockMin(results) },
+
+        "max"               to { results, _ -> computeBlockMax(results) },
+        "maximum"           to { results, _ -> computeBlockMax(results) },
+
         "last"              to { results, _ -> computePreviousLineResult(results) },
         "prev"              to { results, _ -> computePreviousLineResult(results) },
         "previous"          to { results, _ -> computePreviousLineResult(results) },
@@ -403,6 +409,132 @@ object MathEngine {
         }
 
         return EvaluationResult(sumValue, targetUnitSymbol)
+    }
+
+    private fun computeBlockMax(lineResults: List<EvaluationResult?>): EvaluationResult {
+        val blockResults = mutableListOf<EvaluationResult>()
+        for (i in lineResults.indices.reversed()) {
+            val result = lineResults[i] ?: break
+            blockResults.add(0, result)
+        }
+
+        if (blockResults.isEmpty()) return EvaluationResult(BigDecimal.ZERO)
+
+        var expectedCategory: UnitCategory? = null
+        var firstUnitSymbol: String? = null
+        for (res in blockResults) {
+            if (res.unit != null) {
+                val u = UnitConverter.findUnit(res.unit)
+                if (isPhysicalCategory(u?.category)) {
+                    expectedCategory = u?.category
+                    firstUnitSymbol = res.unit
+                    break
+                }
+            }
+        }
+
+        // Target unit for final result is the unit of the LAST line with a physical unit
+        var targetUnitSymbol: String? = null
+        for (i in blockResults.indices.reversed()) {
+            val u = blockResults[i].unit?.let { UnitConverter.findUnit(it) }
+            if (isPhysicalCategory(u?.category)) {
+                targetUnitSymbol = blockResults[i].unit
+                break
+            }
+        }
+
+        var maxValue = BigDecimal.ZERO
+        for (result in blockResults) {
+            val resultValue = result.value ?: BigDecimal.ZERO
+            val resultUnit = result.unit?.let { UnitConverter.findUnit(it) }
+            val resultCategory = resultUnit?.category
+
+            if (expectedCategory != null) {
+                // Block contains physical units: all lines must match that category
+                if (!isPhysicalCategory(resultCategory) || resultCategory != expectedCategory) {
+                    val expectedName = firstUnitSymbol?.let {
+                        UnitConverter.findUnit(it)?.name?.lowercase()?.replaceFirstChar { it.uppercase() }
+                    } ?: expectedCategory.name.lowercase().replaceFirstChar { it.uppercase() }
+                    val resultName =
+                        resultUnit?.name?.lowercase()?.replaceFirstChar { it.uppercase() } ?: "unitless number"
+                    throw EvalException("Maximum of `$expectedName` and `$resultName` is not supported")
+                }
+
+            } else {
+                // Block contains no physical units: all lines must be non-physical
+                if (isPhysicalCategory(resultCategory)) {
+                    throw EvalException("Maximum of physical and unitless values is not supported")
+                }
+            }
+
+            if (resultValue > maxValue)
+                maxValue = resultValue
+        }
+
+        return EvaluationResult(maxValue, targetUnitSymbol)
+    }
+
+    private fun computeBlockMin(lineResults: List<EvaluationResult?>): EvaluationResult {
+        val blockResults = mutableListOf<EvaluationResult>()
+        for (i in lineResults.indices.reversed()) {
+            val result = lineResults[i] ?: break
+            blockResults.add(0, result)
+        }
+
+        if (blockResults.isEmpty()) return EvaluationResult(BigDecimal.ZERO)
+
+        var expectedCategory: UnitCategory? = null
+        var firstUnitSymbol: String? = null
+        for (res in blockResults) {
+            if (res.unit != null) {
+                val u = UnitConverter.findUnit(res.unit)
+                if (isPhysicalCategory(u?.category)) {
+                    expectedCategory = u?.category
+                    firstUnitSymbol = res.unit
+                    break
+                }
+            }
+        }
+
+        // Target unit for final result is the unit of the LAST line with a physical unit
+        var targetUnitSymbol: String? = null
+        for (i in blockResults.indices.reversed()) {
+            val u = blockResults[i].unit?.let { UnitConverter.findUnit(it) }
+            if (isPhysicalCategory(u?.category)) {
+                targetUnitSymbol = blockResults[i].unit
+                break
+            }
+        }
+
+        var minValue = BigDecimal.ZERO
+        for (result in blockResults) {
+            val resultValue = result.value ?: BigDecimal.ZERO
+            val resultUnit = result.unit?.let { UnitConverter.findUnit(it) }
+            val resultCategory = resultUnit?.category
+
+            if (expectedCategory != null) {
+                // Block contains physical units: all lines must match that category
+                if (!isPhysicalCategory(resultCategory) || resultCategory != expectedCategory) {
+                    val expectedName = firstUnitSymbol?.let {
+                        UnitConverter.findUnit(it)?.name?.lowercase()?.replaceFirstChar { it.uppercase() }
+                    } ?: expectedCategory.name.lowercase().replaceFirstChar { it.uppercase() }
+                    val resultName =
+                        resultUnit?.name?.lowercase()?.replaceFirstChar { it.uppercase() } ?: "unitless number"
+                    throw EvalException("Maximum of `$expectedName` and `$resultName` is not supported")
+                }
+
+            } else {
+                // Block contains no physical units: all lines must be non-physical
+                if (isPhysicalCategory(resultCategory)) {
+                    throw EvalException("Maximum of physical and unitless values is not supported")
+                }
+            }
+
+            if (resultValue > minValue)
+                minValue = resultValue
+        }
+
+        return EvaluationResult(minValue, targetUnitSymbol)
     }
 
     /**

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/MathEngine.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/MathEngine.kt
@@ -530,7 +530,7 @@ object MathEngine {
                 }
             }
 
-            if (resultValue > minValue)
+            if (resultValue < minValue)
                 minValue = resultValue
         }
 

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/MathEngine.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/MathEngine.kt
@@ -353,188 +353,105 @@ object MathEngine {
         }
     }
 
-    private fun computeBlockSum(lineResults: List<EvaluationResult?>): EvaluationResult {
+    private fun getBlockResults(lineResults: List<EvaluationResult?>): List<EvaluationResult> {
         val blockResults = mutableListOf<EvaluationResult>()
         for (i in lineResults.indices.reversed()) {
             val result = lineResults[i] ?: break
             blockResults.add(0, result)
         }
+        return blockResults
+    }
 
-        if (blockResults.isEmpty()) return EvaluationResult(BigDecimal.ZERO)
-
+    private fun validateUnitsAndGetTarget(results: List<EvaluationResult>, operationName: String): String? {
         var expectedCategory: UnitCategory? = null
         var firstUnitSymbol: String? = null
-        for (res in blockResults) {
-            if (res.unit != null) {
-                val u = UnitConverter.findUnit(res.unit)
-                if (isPhysicalCategory(u?.category)) {
-                    expectedCategory = u?.category
-                    firstUnitSymbol = res.unit
-                    break
-                }
-            }
-        }
-
-        // Target unit for final result is the unit of the LAST line with a physical unit
-        var targetUnitSymbol: String? = null
-        for (i in blockResults.indices.reversed()) {
-            val u = blockResults[i].unit?.let { UnitConverter.findUnit(it) }
-            if (isPhysicalCategory(u?.category)) {
-                targetUnitSymbol = blockResults[i].unit
+        for (res in results) {
+            val u = res.unit?.let { UnitConverter.findUnit(it) }
+            val cat = u?.category
+            if (isPhysicalCategory(cat)) {
+                expectedCategory = cat
+                firstUnitSymbol = res.unit
                 break
             }
         }
 
-        var sumValue = BigDecimal.ZERO
-        for (result in blockResults) {
-            val resultValue = result.value ?: BigDecimal.ZERO
+        var targetUnitSymbol: String? = null
+        for (i in results.indices.reversed()) {
+            val u = results[i].unit?.let { UnitConverter.findUnit(it) }
+            if (isPhysicalCategory(u?.category)) {
+                targetUnitSymbol = results[i].unit
+                break
+            }
+        }
+
+        for (result in results) {
             val resultUnit = result.unit?.let { UnitConverter.findUnit(it) }
             val resultCategory = resultUnit?.category
 
             if (expectedCategory != null) {
-                // Block contains physical units: all lines must match that category
                 if (!isPhysicalCategory(resultCategory) || resultCategory != expectedCategory) {
                     val expectedName = firstUnitSymbol?.let { UnitConverter.findUnit(it)?.name?.lowercase()?.replaceFirstChar { it.uppercase() } } ?: expectedCategory.name.lowercase().replaceFirstChar { it.uppercase() }
                     val resultName = resultUnit?.name?.lowercase()?.replaceFirstChar { it.uppercase() } ?: "unitless number"
-                    throw EvalException("Summation of `$expectedName` and `$resultName` is not supported")
+                    throw EvalException("$operationName of `$expectedName` and `$resultName` is not supported")
                 }
-                sumValue = sumValue.add(resultValue)
             } else {
-                // Block contains no physical units: all lines must be non-physical
                 if (isPhysicalCategory(resultCategory)) {
-                    throw EvalException("Summation of physical and unitless values is not supported")
+                    throw EvalException("$operationName of physical and unitless values is not supported")
                 }
-                sumValue = sumValue.add(resultValue)
             }
+        }
+        return targetUnitSymbol
+    }
+
+    private fun computeBlockSum(lineResults: List<EvaluationResult?>): EvaluationResult {
+        val blockResults = getBlockResults(lineResults)
+        if (blockResults.isEmpty()) return EvaluationResult(BigDecimal.ZERO)
+
+        val targetUnitSymbol = validateUnitsAndGetTarget(blockResults, "Summation")
+
+        var sumValue = BigDecimal.ZERO
+        for (result in blockResults) {
+            val resultValue = result.value ?: BigDecimal.ZERO
+            sumValue = sumValue.add(resultValue)
         }
 
         return EvaluationResult(sumValue, targetUnitSymbol)
     }
 
     private fun computeBlockMax(lineResults: List<EvaluationResult?>): EvaluationResult {
-        val blockResults = mutableListOf<EvaluationResult>()
-        for (i in lineResults.indices.reversed()) {
-            val result = lineResults[i] ?: break
-            blockResults.add(0, result)
-        }
-
+        val blockResults = getBlockResults(lineResults)
         if (blockResults.isEmpty()) return EvaluationResult(BigDecimal.ZERO)
 
-        var expectedCategory: UnitCategory? = null
-        var firstUnitSymbol: String? = null
-        for (res in blockResults) {
-            if (res.unit != null) {
-                val u = UnitConverter.findUnit(res.unit)
-                if (isPhysicalCategory(u?.category)) {
-                    expectedCategory = u?.category
-                    firstUnitSymbol = res.unit
-                    break
-                }
-            }
-        }
-
-        // Target unit for final result is the unit of the LAST line with a physical unit
-        var targetUnitSymbol: String? = null
-        for (i in blockResults.indices.reversed()) {
-            val u = blockResults[i].unit?.let { UnitConverter.findUnit(it) }
-            if (isPhysicalCategory(u?.category)) {
-                targetUnitSymbol = blockResults[i].unit
-                break
-            }
-        }
+        val targetUnitSymbol = validateUnitsAndGetTarget(blockResults, "Maximum")
 
         var maxValue: BigDecimal? = null
         for (result in blockResults) {
-            val resultValue = result.value ?: BigDecimal.ZERO
-            val resultUnit = result.unit?.let { UnitConverter.findUnit(it) }
-            val resultCategory = resultUnit?.category
-
-            if (expectedCategory != null) {
-                // Block contains physical units: all lines must match that category
-                if (!isPhysicalCategory(resultCategory) || resultCategory != expectedCategory) {
-                    val expectedName = firstUnitSymbol?.let {
-                        UnitConverter.findUnit(it)?.name?.lowercase()?.replaceFirstChar { it.uppercase() }
-                    } ?: expectedCategory.name.lowercase().replaceFirstChar { it.uppercase() }
-                    val resultName =
-                        resultUnit?.name?.lowercase()?.replaceFirstChar { it.uppercase() } ?: "unitless number"
-                    throw EvalException("Maximum of `$expectedName` and `$resultName` is not supported")
-                }
-
-            } else {
-                // Block contains no physical units: all lines must be non-physical
-                if (isPhysicalCategory(resultCategory)) {
-                    throw EvalException("Maximum of physical and unitless values is not supported")
-                }
-            }
+            val resultValue = result.value
+                ?: throw EvalException("Maximum of non-numeric values is not supported")
 
             if (maxValue == null || resultValue > maxValue)
                 maxValue = resultValue
         }
 
-        return EvaluationResult(maxValue, targetUnitSymbol)
+        return EvaluationResult(maxValue ?: BigDecimal.ZERO, targetUnitSymbol)
     }
 
     private fun computeBlockMin(lineResults: List<EvaluationResult?>): EvaluationResult {
-        val blockResults = mutableListOf<EvaluationResult>()
-        for (i in lineResults.indices.reversed()) {
-            val result = lineResults[i] ?: break
-            blockResults.add(0, result)
-        }
-
+        val blockResults = getBlockResults(lineResults)
         if (blockResults.isEmpty()) return EvaluationResult(BigDecimal.ZERO)
 
-        var expectedCategory: UnitCategory? = null
-        var firstUnitSymbol: String? = null
-        for (res in blockResults) {
-            if (res.unit != null) {
-                val u = UnitConverter.findUnit(res.unit)
-                if (isPhysicalCategory(u?.category)) {
-                    expectedCategory = u?.category
-                    firstUnitSymbol = res.unit
-                    break
-                }
-            }
-        }
-
-        // Target unit for final result is the unit of the LAST line with a physical unit
-        var targetUnitSymbol: String? = null
-        for (i in blockResults.indices.reversed()) {
-            val u = blockResults[i].unit?.let { UnitConverter.findUnit(it) }
-            if (isPhysicalCategory(u?.category)) {
-                targetUnitSymbol = blockResults[i].unit
-                break
-            }
-        }
+        val targetUnitSymbol = validateUnitsAndGetTarget(blockResults, "Minimum")
 
         var minValue: BigDecimal? = null
         for (result in blockResults) {
-            val resultValue = result.value ?: BigDecimal.ZERO
-            val resultUnit = result.unit?.let { UnitConverter.findUnit(it) }
-            val resultCategory = resultUnit?.category
-
-            if (expectedCategory != null) {
-                // Block contains physical units: all lines must match that category
-                if (!isPhysicalCategory(resultCategory) || resultCategory != expectedCategory) {
-                    val expectedName = firstUnitSymbol?.let {
-                        UnitConverter.findUnit(it)?.name?.lowercase()?.replaceFirstChar { it.uppercase() }
-                    } ?: expectedCategory.name.lowercase().replaceFirstChar { it.uppercase() }
-                    val resultName =
-                        resultUnit?.name?.lowercase()?.replaceFirstChar { it.uppercase() } ?: "unitless number"
-                    throw EvalException("Minimum of `$expectedName` and `$resultName` is not supported")
-                }
-
-            } else {
-                // Block contains no physical units: all lines must be non-physical
-                if (isPhysicalCategory(resultCategory)) {
-                    throw EvalException("Minimum of physical and unitless values is not supported")
-                }
-            }
+            val resultValue = result.value
+                ?: throw EvalException("Minimum of non-numeric values is not supported")
 
             if (minValue == null || resultValue < minValue)
                 minValue = resultValue
         }
 
-        return EvaluationResult(minValue, targetUnitSymbol)
+        return EvaluationResult(minValue ?: BigDecimal.ZERO, targetUnitSymbol)
     }
 
     /**
@@ -547,109 +464,30 @@ object MathEngine {
      * physical unit.
      */
     private fun computeGrandTotal(lineResults: List<EvaluationResult?>): EvaluationResult {
-        // Collect every non-null result (order preserved, no block-boundary stop)
         val allResults = lineResults.filterNotNull()
-
         if (allResults.isEmpty()) return EvaluationResult(BigDecimal.ZERO)
 
-        // Determine expected physical category from the FIRST line with a physical unit
-        var expectedCategory: UnitCategory? = null
-        var firstUnitSymbol: String? = null
-        for (res in allResults) {
-            val u = res.unit?.let { UnitConverter.findUnit(it) }
-            if (isPhysicalCategory(u?.category)) {
-                expectedCategory = u?.category
-                firstUnitSymbol = res.unit
-                break
-            }
-        }
-
-        // Target display unit is taken from the LAST line with a physical unit
-        var targetUnitSymbol: String? = null
-        for (i in allResults.indices.reversed()) {
-            val u = allResults[i].unit?.let { UnitConverter.findUnit(it) }
-            if (isPhysicalCategory(u?.category)) {
-                targetUnitSymbol = allResults[i].unit
-                break
-            }
-        }
+        val targetUnitSymbol = validateUnitsAndGetTarget(allResults, "Summation")
 
         var sumValue = BigDecimal.ZERO
         for (result in allResults) {
             val resultValue = result.value ?: BigDecimal.ZERO
-            val resultUnit = result.unit?.let { UnitConverter.findUnit(it) }
-            val resultCategory = resultUnit?.category
-
-            if (expectedCategory != null) {
-                // Block contains physical units: all lines must match that category
-                if (!isPhysicalCategory(resultCategory) || resultCategory != expectedCategory) {
-                    val expectedName = firstUnitSymbol?.let { UnitConverter.findUnit(it)?.name?.lowercase()?.replaceFirstChar { it.uppercase() } } ?: expectedCategory.name.lowercase().replaceFirstChar { it.uppercase() }
-                    val resultName = resultUnit?.name?.lowercase()?.replaceFirstChar { it.uppercase() } ?: "unitless number"
-                    throw EvalException("Summation of `$expectedName` and `$resultName` is not supported")
-                }
-                sumValue = sumValue.add(resultValue)
-            } else {
-                // Block contains no physical units: all lines must be non-physical
-                if (isPhysicalCategory(resultCategory)) {
-                    throw EvalException("Summation of physical and unitless values is not supported")
-                }
-                sumValue = sumValue.add(resultValue)
-            }
+            sumValue = sumValue.add(resultValue)
         }
 
         return EvaluationResult(sumValue, targetUnitSymbol)
     }
 
     private fun computeBlockAverage(lineResults: List<EvaluationResult?>): EvaluationResult {
-        val blockResults = mutableListOf<EvaluationResult>()
-        for (i in lineResults.indices.reversed()) {
-            val result = lineResults[i] ?: break
-            blockResults.add(0, result)
-        }
-
+        val blockResults = getBlockResults(lineResults)
         if (blockResults.isEmpty()) return EvaluationResult(BigDecimal.ZERO)
 
-        // Use logic similar to sum for dimension checking
-        var expectedCategory: UnitCategory? = null
-        var firstUnitSymbol: String? = null
-        for (res in blockResults) {
-            val u = res.unit?.let { UnitConverter.findUnit(it) }
-            val cat = u?.category
-            if (isPhysicalCategory(cat)) {
-                expectedCategory = cat
-                firstUnitSymbol = res.unit
-                break
-            }
-        }
-
-        var targetUnitSymbol: String? = null
-        for (i in blockResults.indices.reversed()) {
-            val u = blockResults[i].unit?.let { UnitConverter.findUnit(it) }
-            if (isPhysicalCategory(u?.category)) {
-                targetUnitSymbol = blockResults[i].unit
-                break
-            }
-        }
+        val targetUnitSymbol = validateUnitsAndGetTarget(blockResults, "Average")
 
         var sumValue = BigDecimal.ZERO
         var count = 0
         for (result in blockResults) {
             val resultValue = result.value ?: BigDecimal.ZERO
-            val resultUnit = result.unit?.let { UnitConverter.findUnit(it) }
-            val resultCategory = resultUnit?.category
-
-            if (expectedCategory != null) {
-                if (!isPhysicalCategory(resultCategory) || resultCategory != expectedCategory) {
-                    val expectedName = firstUnitSymbol?.let { UnitConverter.findUnit(it)?.name?.lowercase()?.replaceFirstChar { it.uppercase() } } ?: expectedCategory.name.lowercase().replaceFirstChar { it.uppercase() }
-                    val resultName = resultUnit?.name?.lowercase()?.replaceFirstChar { it.uppercase() } ?: "unitless number"
-                    throw EvalException("Average of `$expectedName` and `$resultName` is not supported")
-                }
-            } else {
-                if (isPhysicalCategory(resultCategory)) {
-                    throw EvalException("Average of physical and unitless values is not supported")
-                }
-            }
-
             sumValue = sumValue.add(resultValue)
             count++
         }

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/MathEngine.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/MathEngine.kt
@@ -506,7 +506,7 @@ object MathEngine {
             }
         }
 
-        var minValue = BigDecimal.ZERO
+        var minValue: BigDecimal? = null
         for (result in blockResults) {
             val resultValue = result.value ?: BigDecimal.ZERO
             val resultUnit = result.unit?.let { UnitConverter.findUnit(it) }
@@ -520,17 +520,17 @@ object MathEngine {
                     } ?: expectedCategory.name.lowercase().replaceFirstChar { it.uppercase() }
                     val resultName =
                         resultUnit?.name?.lowercase()?.replaceFirstChar { it.uppercase() } ?: "unitless number"
-                    throw EvalException("Maximum of `$expectedName` and `$resultName` is not supported")
+                    throw EvalException("Minimum of `$expectedName` and `$resultName` is not supported")
                 }
 
             } else {
                 // Block contains no physical units: all lines must be non-physical
                 if (isPhysicalCategory(resultCategory)) {
-                    throw EvalException("Maximum of physical and unitless values is not supported")
+                    throw EvalException("Minimum of physical and unitless values is not supported")
                 }
             }
 
-            if (resultValue < minValue)
+            if (minValue == null || resultValue < minValue)
                 minValue = resultValue
         }
 

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/utils/SyntaxUtils.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/utils/SyntaxUtils.kt
@@ -19,7 +19,7 @@ object SyntaxUtils {
 
     /** Identifiers that are highlighted as keywords rather than variables. */
     private val KEYWORD_NAMES = setOf(
-        "sum", "total", "avg", "average", "last", "prev", "previous", "above", "_",
+        "sum", "total", "avg", "average", "max", "maximum", "min", "minimum", "last", "prev", "previous", "above", "_",
         "lineno", "linenumber", "currentLineNumber"
     )
 

--- a/app/src/test/java/com/vishaltelangre/nerdcalci/core/MathEngineTest.kt
+++ b/app/src/test/java/com/vishaltelangre/nerdcalci/core/MathEngineTest.kt
@@ -1706,6 +1706,84 @@ class MathEngineTest {
     }
 
     @Test
+    fun `min finds smallest result in same block`() =
+            testCalculate("10", "5", "20", "min", "5m", "10", "min") { result ->
+                assertEquals("10.0", result[0].result)
+                assertEquals("5.0", result[1].result)
+                assertEquals("20.0", result[2].result)
+                assertEquals("5.0", result[3].result)
+                assertEquals("5.0 m", result[4].result)
+                assertEquals("10.0", result[5].result)
+                assertError("Minimum of `Meter` and `unitless number` is not supported", result, 6)
+            }
+
+    @Test
+    fun `minimum is an alias for min`() =
+            testCalculate("10", "30", "5", "minimum") { result ->
+                assertEquals("5.0", result[3].result)
+            }
+
+    @Test
+    fun `min with no preceding results is 0`() =
+            testCalculate("min") { result -> assertEquals("0.0", result[0].result) }
+
+    @Test
+    fun `blank line resets the block for min`() =
+            testCalculate("10", "5", "min", "", "20", "15", "min") { result ->
+                assertEquals("5.0", result[2].result)
+                assertEquals("", result[3].result)
+                assertEquals("15.0", result[6].result)
+            }
+
+    @Test
+    fun `min handles all negative numbers correctly`() =
+            testCalculate("-5", "-10", "-3", "min") { result ->
+                assertEquals("-10.0", result[3].result)
+            }
+
+    @Test
+    fun `max finds largest result in same block`() =
+            testCalculate("10", "5", "20", "max", "5m", "10", "max") { result ->
+                assertEquals("10.0", result[0].result)
+                assertEquals("5.0", result[1].result)
+                assertEquals("20.0", result[2].result)
+                assertEquals("20.0", result[3].result)
+                assertEquals("5.0 m", result[4].result)
+                assertEquals("10.0", result[5].result)
+                assertError("Maximum of `Meter` and `unitless number` is not supported", result, 6)
+            }
+
+    @Test
+    fun `maximum is an alias for max`() =
+            testCalculate("10", "30", "5", "maximum") { result ->
+                assertEquals("30.0", result[3].result)
+            }
+
+    @Test
+    fun `max with no preceding results is 0`() =
+            testCalculate("max") { result -> assertEquals("0.0", result[0].result) }
+
+    @Test
+    fun `blank line resets the block for max`() =
+            testCalculate("10", "5", "max", "", "20", "15", "max") { result ->
+                assertEquals("10.0", result[2].result)
+                assertEquals("", result[3].result)
+                assertEquals("20.0", result[6].result)
+            }
+
+    @Test
+    fun `max handles all negative numbers correctly`() =
+            testCalculate("-5", "-10", "-3", "max") { result ->
+                assertEquals("-3.0", result[3].result)
+            }
+
+    @Test
+    fun `min and max ignore non-numeric results like dates and throw exception`() =
+            testCalculate("10", "\"Hello\"", "min") { result ->
+                assertError("Minimum of non-numeric values is not supported", result, 2)
+            }
+
+    @Test
     fun `grand_total sums all results above across block boundaries`() =
             testCalculate("a = 10", "b = 20", "total", "", "c = 5", "total", "grand_total") { result
                 ->
@@ -1949,6 +2027,30 @@ class MathEngineTest {
     fun `average alias assignment is blocked`() =
             testCalculate("average = 5") { result ->
                 assertError("`average` is a reserved name and cannot be changed", result, 0)
+            }
+
+    @Test
+    fun `min alias assignment is blocked`() =
+            testCalculate("min = 5") { result ->
+                assertError("`min` is a reserved name and cannot be changed", result, 0)
+            }
+
+    @Test
+    fun `minimum alias assignment is blocked`() =
+            testCalculate("minimum = 5") { result ->
+                assertError("`minimum` is a reserved name and cannot be changed", result, 0)
+            }
+
+    @Test
+    fun `max alias assignment is blocked`() =
+            testCalculate("max = 5") { result ->
+                assertError("`max` is a reserved name and cannot be changed", result, 0)
+            }
+
+    @Test
+    fun `maximum alias assignment is blocked`() =
+            testCalculate("maximum = 5") { result ->
+                assertError("`maximum` is a reserved name and cannot be changed", result, 0)
             }
 
     @Test

--- a/fastlane/metadata/android/en-US/changelogs/493.txt
+++ b/fastlane/metadata/android/en-US/changelogs/493.txt
@@ -1,0 +1,1 @@
+- Added `min`/`minimum` and `max`/`maximum` dynamic variables to find the smallest or largest value in the preceding block (Issue: #220).


### PR DESCRIPTION
This PR introduces a minimum and maximum function into the app.

> Very nice project and I hope this PR is welcome ^^

## Solution

I copied most of the code over from `computeBlockSum` to make it easier for me and just stay in the coding guidelines for this project.
This also means the functionality is pretty similar and only changes at the compare part.

## Improvement

I realize there could be an improvement in code to reuse code snippets more often and maybe have min/max/avg in some way related to skip over multiple recalculations if it comes to it.

For now I wanted to include this feature quick to have it work.

## Screenshot

<img width="636" height="344" alt="image" src="https://github.com/user-attachments/assets/aa0d3547-bf76-4833-b955-c1018896f623" />

> Screenshot with fake numbers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dynamic `min`/`minimum` and `max`/`maximum` keywords to return the smallest/largest value from the preceding block (reset by blank/comment/error lines).
  * Supports aliases (`minimum`→`min`, `maximum`→`max`) and enforces that these reserved keywords can’t be reassigned.
* **Bug Fixes**
  * Strengthened numeric comparison rules and unit validation for block-based min/max results; empty blocks yield `0`.
* **Documentation**
  * Updated reference guides and changelogs with usage examples and behavior details.
* **Tests**
  * Added coverage for block boundaries, negatives, aliases, and non-numeric handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->