### PR TITLE
Add support for decimal-precision sub-day time unit queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.9.4] - 2026-07-23
+### Added
+- Added support for sub-day time unit queries (`hours since`, `minutes since`, `seconds since`, etc.) and decimal precision for date/time queries (Issue: #218).
+
 ## [4.9.3] - 2026-07-07
 ### Added
 - Added `min`/`minimum` and `max`/`maximum` dynamic variables to find the smallest or largest value in the preceding block (Issue: #220).

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -29,6 +29,7 @@
   - [Sum / Total](#sum--total)
   - [Grand total](#grand-total)
   - [Average](#average)
+  - [Min / Max](#min--max)
   - [Reference to previous line result](#reference-to-previous-line-result)
   - [Reference to current line number](#reference-to-current-line-number)
 - [8. User-defined functions](#8-user-defined-functions)
@@ -80,6 +81,10 @@
   - [Relative keywords](#relative-keywords)
   - [Date arithmetic](#date-arithmetic)
   - [Intervals and duration queries](#intervals-and-duration-queries)
+    - [1. Supported time units in queries](#1-supported-time-units-in-queries)
+    - [2. Query operators and syntax](#2-query-operators-and-syntax)
+    - [3. Unit projections and formatting](#3-unit-projections-and-formatting)
+    - [Summary Table](#summary-table)
   - [Timezones](#timezones)
   - [Date component extraction](#date-component-extraction)
   - [Output formats](#output-formats)
@@ -1219,19 +1224,74 @@ Durations can be combined freely: `2 years 3 months 1 week 5 days`.
 
 ### Intervals and duration queries
 
-Calculate the time between two dates or find out how many days have passed. You can also project the result into a specific time unit using `in <unit>`.
+NerdCalci provides date and time interval queries for measuring elapsed time, calculating remaining time, or projecting differences into specific time units.
 
-| Operation             | Example                                               | Result                     |
-| :-------------------- | :---------------------------------------------------- | :------------------------- |
-| **Interval**          | `date(2024, 1, 1) to today`                           | `4 mo 1 wk` (Duration)     |
-| **Year interval**     | `1978 to 2021`                                        | `43 y`                     |
-| **Days since**        | `days since date(2024, 1, 1)`                         | `122 d` (Total days)       |
-| **Days till**         | `days till date(2024, 12, 25)`                        | `237 d`                    |
-| **Days between**      | `days between today and tomorrow`                     | `1 d`                      |
-| **Absolute interval** | `between today and date(2025, 1, 1)`                  | `1 y 4 mo 4 d`             |
-| **Inclusive count**   | `today through tomorrow`                              | `2 d` (Includes both days) |
-| **Projection**        | `days since date(2024, 1, 1) in hours`                | `2928 h`                   |
-| **Distance**          | `days between date(2024,1,2) and date(2024,1,1) in s` | `86400 s`                  |
+#### 1. Supported time units in queries
+
+You can query interval counts using any standard time unit symbol or name:
+*   **Days**: `days`, `day`, `d`
+*   **Hours**: `hours`, `hour`, `hrs`, `hr`, `h`
+*   **Minutes**: `minutes`, `minute`, `mins`, `min`
+*   **Seconds**: `seconds`, `second`, `secs`, `sec`, `s`
+*   **Weeks**: `weeks`, `week`, `wks`, `wk`
+*   **Months**: `months`, `month`, `mo`
+*   **Years**: `years`, `year`, `yrs`, `yr`, `y`
+
+#### 2. Query operators and syntax
+
+*   **`<unit> since <date/datetime>`**: Calculates the elapsed time from a target date or datetime up to the present.
+    *   If the target is a plain `Date` (e.g. `date(2024, 1, 1)`), it measures calendar days relative to `today` (midnight).
+    *   If the target is a `DateTime` with time components (e.g. `datetimeZ(2026, 6, 9, 21, 21, 11, "GMT")` or `now - 2 hours`), it measures elapsed time down to the exact second relative to `now`, returning decimal precision.
+    *   *Examples*:
+        *   `days since date(2024, 1, 1)` &rarr; `934 d` (Integer calendar days)
+        *   `days since datetimeZ(2026, 6, 9, 21, 21, 11, "GMT")` &rarr; `17.7769560185 d` (High-precision decimal days)
+        *   `hours since mydate` &rarr; `426.6469444444 h` (Precise elapsed hours)
+        *   `minutes since mydate` &rarr; `25598.8166666667 min` (Precise elapsed minutes)
+        *   `seconds since mydate` &rarr; `1535929 s` (Precise elapsed seconds)
+
+*   **`<unit> till <date/datetime>`** or **`<unit> until <date/datetime>`**: Calculates the remaining time from the present until a target date or datetime.
+    *   *Examples*:
+        *   `days till date(2026, 12, 31)` &rarr; `160 d`
+        *   `hours until datetime(2026, 12, 31, 23, 59, 59)` &rarr; `3847.7997222222 h`
+
+*   **`<unit> between <start> and <end>`**: Calculates the distance/difference between two dates or datetimes. The result is always non-negative (absolute).
+    *   *Examples*:
+        *   `days between date(2024, 1, 1) and date(2024, 1, 10)` &rarr; `9 d`
+        *   `hours between datetime(2024, 1, 1, 12, 0, 0) and datetime(2024, 1, 2, 18, 30, 0)` &rarr; `30.5 h`
+        *   `minutes between datetime(2024, 1, 1, 12, 0, 0) and datetime(2024, 1, 1, 12, 45, 0)` &rarr; `45 min`
+
+*   **`<start> to <end>`**: Calculates a calendar-aware interval duration (expressed in years, months, weeks, days).
+    *   *Examples*:
+        *   `date(2024, 1, 1) to date(2024, 5, 15)` &rarr; `4 mo 14 d`
+        *   `1978 to 2021` &rarr; `43 y`
+
+*   **`<start> through <end>`**: Inclusive calendar count including both start and end dates.
+    *   *Examples*:
+        *   `today through tomorrow` &rarr; `2 d`
+        *   `date(2024, 1, 1) through date(2024, 1, 31) in days` &rarr; `31 d`
+
+#### 3. Unit projections and formatting
+
+You can append `in <unit>` to project any date/time query into another target time unit:
+*   `days since date(2024, 1, 1) in hours` &rarr; `22416 h`
+*   `days between date(2024, 1, 1) and date(2024, 1, 2) in seconds` &rarr; `86400 s`
+
+You can also apply standard math functions to date/time query results:
+*   `ceil(days since mydate)` &rarr; `18 d`
+*   `floor(days since mydate)` &rarr; `17 d`
+*   `(hours since mydate) / 24` &rarr; `17.7769560185`
+
+#### Summary Table
+
+| Operation               | Syntax Example                                         | Output Format      | Description                                                            |
+| :---------------------- | :----------------------------------------------------- | :----------------- | :--------------------------------------------------------------------- |
+| **Days since Date**     | `days since date(2024, 1, 1)`                          | `934 d`            | Days elapsed since midnight of a plain date                            |
+| **Time unit query**     | `hours since datetimeZ(2026, 6, 9, 21, 21, 11, "GMT")` | `426.6469444444 h` | Precise elapsed time in requested unit (hours, minutes, seconds, etc.) |
+| **Time till Date/Time** | `hours until date(2026, 12, 31)`                       | `3847.8 h`         | Precise hours remaining until target date/datetime                     |
+| **Time between**        | `hours between dt1 and dt2`                            | `30.5 h`           | Absolute difference between two datetimes                              |
+| **Calendar interval**   | `date(2024, 1, 1) to today`                            | `4 mo 1 wk`        | Calendar-aware duration (years/months/weeks/days)                      |
+| **Unit projection**     | `days since date(2024, 1, 1) in hours`                 | `22416 h`          | Projects date difference into target unit                              |
+| **Rounded query**       | `ceil(days since mydate)`                              | `18.0 d`           | Forces integer rounding on fractional queries                          |
 
 > **Note**: While `to`, `through`, `since`, and `till` are signed (e.g., `tomorrow to today` is `-1 d`), the `between` operator is always absolute (e.g., `between tomorrow and today` is `1 d`).
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1243,16 +1243,16 @@ You can query interval counts using any standard time unit symbol or name:
     *   If the target is a plain `Date` (e.g. `date(2024, 1, 1)`), it measures calendar days relative to `today` (midnight).
     *   If the target is a `DateTime` with time components (e.g. `datetimeZ(2026, 6, 9, 21, 21, 11, "GMT")` or `now - 2 hours`), it measures elapsed time down to the exact second relative to `now`, returning decimal precision.
     *   *Examples*:
-        *   `days since date(2024, 1, 1)` &rarr; `934 d` (Integer calendar days)
-        *   `days since datetimeZ(2026, 6, 9, 21, 21, 11, "GMT")` &rarr; `17.7769560185 d` (High-precision decimal days)
-        *   `hours since mydate` &rarr; `426.6469444444 h` (Precise elapsed hours)
-        *   `minutes since mydate` &rarr; `25598.8166666667 min` (Precise elapsed minutes)
-        *   `seconds since mydate` &rarr; `1535929 s` (Precise elapsed seconds)
+        *   `days since date(2024, 1, 1)` &rarr; `<elapsed_days> d` (Whole calendar days elapsed)
+        *   `days since datetimeZ(2026, 6, 9, 21, 21, 11, "GMT")` &rarr; `<elapsed_decimal_days> d` (High-precision decimal days, e.g. `17.7769... d`)
+        *   `hours since mydate` &rarr; `<elapsed_hours> h` (Precise elapsed hours, e.g. `426.64... h`)
+        *   `minutes since mydate` &rarr; `<elapsed_minutes> min` (Precise elapsed minutes)
+        *   `seconds since mydate` &rarr; `<elapsed_seconds> s` (Precise elapsed seconds)
 
 *   **`<unit> till <date/datetime>`** or **`<unit> until <date/datetime>`**: Calculates the remaining time from the present until a target date or datetime.
     *   *Examples*:
-        *   `days till date(2026, 12, 31)` &rarr; `160 d`
-        *   `hours until datetime(2026, 12, 31, 23, 59, 59)` &rarr; `3847.7997222222 h`
+        *   `days till date(2026, 12, 31)` &rarr; `<remaining_days> d`
+        *   `hours until datetime(2026, 12, 31, 23, 59, 59)` &rarr; `<remaining_hours> h`
 
 *   **`<unit> between <start> and <end>`**: Calculates the distance/difference between two dates or datetimes. The result is always non-negative (absolute).
     *   *Examples*:
@@ -1273,25 +1273,24 @@ You can query interval counts using any standard time unit symbol or name:
 #### 3. Unit projections and formatting
 
 You can append `in <unit>` to project any date/time query into another target time unit:
-*   `days since date(2024, 1, 1) in hours` &rarr; `22416 h`
+*   `days since date(2024, 1, 1) in hours` &rarr; `<elapsed_hours> h`
 *   `days between date(2024, 1, 1) and date(2024, 1, 2) in seconds` &rarr; `86400 s`
 
 You can also apply standard math functions to date/time query results:
-*   `ceil(days since mydate)` &rarr; `18 d`
-*   `floor(days since mydate)` &rarr; `17 d`
-*   `(hours since mydate) / 24` &rarr; `17.7769560185`
+*   `ceil(days since mydate)` &rarr; `<rounded_days>.0 d`
+*   `floor(days since mydate)` &rarr; `<rounded_days>.0 d`
 
 #### Summary Table
 
-| Operation               | Syntax Example                                         | Output Format      | Description                                                            |
-| :---------------------- | :----------------------------------------------------- | :----------------- | :--------------------------------------------------------------------- |
-| **Days since Date**     | `days since date(2024, 1, 1)`                          | `934 d`            | Days elapsed since midnight of a plain date                            |
-| **Time unit query**     | `hours since datetimeZ(2026, 6, 9, 21, 21, 11, "GMT")` | `426.6469444444 h` | Precise elapsed time in requested unit (hours, minutes, seconds, etc.) |
-| **Time till Date/Time** | `hours until date(2026, 12, 31)`                       | `3847.8 h`         | Precise hours remaining until target date/datetime                     |
-| **Time between**        | `hours between dt1 and dt2`                            | `30.5 h`           | Absolute difference between two datetimes                              |
-| **Calendar interval**   | `date(2024, 1, 1) to today`                            | `4 mo 1 wk`        | Calendar-aware duration (years/months/weeks/days)                      |
-| **Unit projection**     | `days since date(2024, 1, 1) in hours`                 | `22416 h`          | Projects date difference into target unit                              |
-| **Rounded query**       | `ceil(days since mydate)`                              | `18.0 d`           | Forces integer rounding on fractional queries                          |
+| Operation               | Syntax Example                                            | Output Format         | Description                                                            |
+| :---------------------- | :-------------------------------------------------------- | :-------------------- | :--------------------------------------------------------------------- |
+| **Days since Date**     | `days since date(2024, 1, 1)`                             | `<elapsed_days> d`    | Whole calendar days elapsed since midnight                             |
+| **Time unit query**     | `hours since datetimeZ(2026, 6, 9, 21, 21, 11, "GMT")`    | `<elapsed_hours> h`   | Precise elapsed time in requested unit (hours, minutes, seconds, etc.) |
+| **Time till Date/Time** | `hours until date(2026, 12, 31)`                          | `<remaining_hours> h` | Precise hours remaining until target date/datetime                     |
+| **Time between**        | `hours between dt1 and dt2`                               | `30.5 h`              | Absolute difference between two datetimes                              |
+| **Calendar interval**   | `date(2024, 1, 1) to date(2024, 5, 15)`                   | `4 mo 14 d`           | Calendar-aware duration (years/months/weeks/days)                      |
+| **Unit projection**     | `days between date(2024, 1, 1) and date(2024, 1, 2) in s` | `86400 s`             | Projects date difference into target unit                              |
+| **Rounded query**       | `ceil(days between dt1 and dt2)`                          | `2.0 d`               | Forces integer rounding on fractional queries                          |
 
 > **Note**: While `to`, `through`, `since`, and `till` are signed (e.g., `tomorrow to today` is `-1 d`), the `between` operator is always absolute (e.g., `between tomorrow and today` is `1 d`).
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
     defaultConfig {
         applicationId = "com.vishaltelangre.nerdcalci"
         minSdk = 23
-        versionCode = 493
-        versionName = "4.9.3"
+        versionCode = 494
+        versionName = "4.9.4"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/Ast.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/Ast.kt
@@ -93,7 +93,7 @@ sealed class Expr {
     data class YearInterval(val fromYear: Expr, val toYear: Expr) : Expr()
 
     /** Day-count query: `days since <date>` / `days till <date>` / `days until <date>` */
-    data class DayCountQuery(val kind: TokenKind, val target: Expr, val projectionUnit: String? = null) : Expr()
+    data class DayCountQuery(val kind: TokenKind, val target: Expr, val unit: String? = null, val projectionUnit: String? = null) : Expr()
 
     /** Timezone conversion or date formatting: `<expr> in "Zone"` / `<expr> as "iso8601"` */
     data class DateModifier(val expr: Expr, val modifier: String, val value: String) : Expr()

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/DateEvaluator.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/DateEvaluator.kt
@@ -125,15 +125,16 @@ object DateEvaluator {
                     rawEndInstant.plusSeconds(86400L) else rawEndInstant
 
                 val duration = java.time.Duration.between(startInstant, endInstant)
-                val totalSeconds = duration.seconds
+                val totalSeconds = BigDecimal.valueOf(duration.seconds).add(BigDecimal.valueOf(duration.nano.toLong(), 9))
 
                 if (projectionUnit.lowercase() in setOf("d", "day", "days")) {
-                    val days = totalSeconds / 86400L
-                    return DateTimeResult.DayCount(if (absolute) Math.abs(days) else days)
+                    val days = totalSeconds.divide(BigDecimal("86400"), java.math.MathContext.DECIMAL128).stripTrailingZeros()
+                    val value = if (absolute) days.abs() else days
+                    return DateTimeResult.DayCount(value)
                 }
 
-                val baseValue = UnitConverter.fromBase(BigDecimal.valueOf(totalSeconds), unit, emptyMap<String, EvaluationResult>()).toLong()
-                val value = if (absolute) Math.abs(baseValue) else baseValue
+                val baseValue = UnitConverter.fromBase(totalSeconds, unit, emptyMap<String, EvaluationResult>()).stripTrailingZeros()
+                val value = if (absolute) baseValue.abs() else baseValue
                 return DateTimeResult.TimeCount(value, unit.symbols.first())
             } else {
                 // Both operands are plain dates — use the original LocalDate-based path.
@@ -143,12 +144,12 @@ object DateEvaluator {
 
                 val totalDays = ChronoUnit.DAYS.between(fromDate, toDate)
                 if (projectionUnit.lowercase() in setOf("d", "day", "days")) {
-                    return DateTimeResult.DayCount(if (absolute) Math.abs(totalDays) else totalDays)
+                    return DateTimeResult.DayCount(BigDecimal.valueOf(if (absolute) Math.abs(totalDays) else totalDays))
                 }
 
-                val totalSeconds = totalDays * 24 * 3600L
-                val baseValue = UnitConverter.fromBase(BigDecimal.valueOf(totalSeconds), unit, emptyMap<String, EvaluationResult>()).toLong()
-                val value = if (absolute) Math.abs(baseValue) else baseValue
+                val totalSeconds = BigDecimal.valueOf(totalDays * 86400L)
+                val baseValue = UnitConverter.fromBase(totalSeconds, unit, emptyMap<String, EvaluationResult>()).stripTrailingZeros()
+                val value = if (absolute) baseValue.abs() else baseValue
                 return DateTimeResult.TimeCount(value, unit.symbols.first())
             }
         }
@@ -337,8 +338,16 @@ object DateEvaluator {
                 "$datePart, $timePart $tzAbbr"
             }
             is DateTimeResult.Duration -> result.delta.format()
-            is DateTimeResult.DayCount -> "${result.days} d"
-            is DateTimeResult.TimeCount -> "${result.value} ${result.unit}"
+            is DateTimeResult.DayCount -> {
+                val stz = result.days.stripTrailingZeros()
+                val d = if (stz.remainder(BigDecimal.ONE).compareTo(BigDecimal.ZERO) == 0) stz.setScale(0) else stz.setScale(10, java.math.RoundingMode.HALF_UP).stripTrailingZeros()
+                "${d.toPlainString()} d"
+            }
+            is DateTimeResult.TimeCount -> {
+                val stz = result.value.stripTrailingZeros()
+                val v = if (stz.remainder(BigDecimal.ONE).compareTo(BigDecimal.ZERO) == 0) stz.setScale(0) else stz.setScale(10, java.math.RoundingMode.HALF_UP).stripTrailingZeros()
+                "${v.toPlainString()} ${result.unit}"
+            }
         }
     }
 

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/DateTimeResult.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/DateTimeResult.kt
@@ -1,5 +1,6 @@
 package com.vishaltelangre.nerdcalci.core
 
+import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.ZonedDateTime
 
@@ -34,11 +35,17 @@ sealed class DateTimeResult {
      * The result of a day-count query: days since / days till / days between.
      * Displayed as "N d".
      */
-    data class DayCount(val days: Long) : DateTimeResult()
+    data class DayCount(val days: BigDecimal) : DateTimeResult() {
+        constructor(days: Long) : this(BigDecimal.valueOf(days))
+        constructor(days: Double) : this(BigDecimal.valueOf(days))
+    }
 
     /**
      * The result of a specific unit count: through ... in hours/minutes/weeks etc.
      * Displayed exactly as "<value> <unit>".
      */
-    data class TimeCount(val value: Long, val unit: String) : DateTimeResult()
+    data class TimeCount(val value: BigDecimal, val unit: String) : DateTimeResult() {
+        constructor(value: Long, unit: String) : this(BigDecimal.valueOf(value), unit)
+        constructor(value: Double, unit: String) : this(BigDecimal.valueOf(value), unit)
+    }
 }

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/Evaluator.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/Evaluator.kt
@@ -106,7 +106,8 @@ class Evaluator(
         }
         is Expr.DayCountQuery -> {
             val target = coerceToDate(evaluate(expr.target))
-            val relativeEndpoint = if (target is DateTimeResult.DateTime) {
+            val isSubDay = isSubDayUnit(expr.unit)
+            val relativeEndpoint = if (target is DateTimeResult.DateTime || isSubDay) {
                 DateEvaluator.resolveRelativeKeyword("now")
             } else {
                 DateEvaluator.resolveRelativeKeyword("today")
@@ -1071,6 +1072,12 @@ class Evaluator(
 
         val seconds = UnitConverter.toBase(amount, unit, variables).toLong()
         return DateTimeDelta(seconds = seconds)
+    }
+
+    private fun isSubDayUnit(unitStr: String?): Boolean {
+        if (unitStr == null) return false
+        val unit = UnitConverter.findUnit(unitStr) ?: return false
+        return unit.category == UnitCategory.TIME && unit.factor < BigDecimal("86400")
     }
 
     private fun applyOp(left: BigDecimal, op: TokenKind, right: BigDecimal): BigDecimal = when (op) {

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/Evaluator.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/Evaluator.kt
@@ -106,10 +106,15 @@ class Evaluator(
         }
         is Expr.DayCountQuery -> {
             val target = coerceToDate(evaluate(expr.target))
-            val today = DateEvaluator.resolveRelativeKeyword("today")
+            val relativeEndpoint = if (target is DateTimeResult.DateTime) {
+                DateEvaluator.resolveRelativeKeyword("now")
+            } else {
+                DateEvaluator.resolveRelativeKeyword("today")
+            }
+
             val res = when (expr.kind) {
-                TokenKind.KW_SINCE -> DateEvaluator.interval(target, today, projectionUnit = expr.projectionUnit ?: "days")
-                TokenKind.KW_TILL, TokenKind.KW_UNTIL -> DateEvaluator.interval(today, target, projectionUnit = expr.projectionUnit ?: "days")
+                TokenKind.KW_SINCE -> DateEvaluator.interval(target, relativeEndpoint, projectionUnit = expr.projectionUnit ?: "days")
+                TokenKind.KW_TILL, TokenKind.KW_UNTIL -> DateEvaluator.interval(relativeEndpoint, target, projectionUnit = expr.projectionUnit ?: "days")
                 else -> throw EvalException("Unsupported day-count query")
             }
             mapDateTimeResult(res)
@@ -1014,19 +1019,20 @@ class Evaluator(
     private fun toDateDelta(result: EvaluationResult): DateTimeDelta {
         result.dateTimeResult?.let {
             if (it is DateTimeResult.Duration) return it.delta
-            if (it is DateTimeResult.DayCount) return DateTimeDelta(days = it.days)
+            if (it is DateTimeResult.DayCount) return DateTimeDelta(days = it.days.toLong())
             if (it is DateTimeResult.TimeCount) {
                 val unit = UnitConverter.findUnit(it.unit)!!
+                val longVal = it.value.toLong()
                 val delta = when (unit.name.lowercase()) {
-                    "year" -> DateTimeDelta(years = it.value)
-                    "month" -> DateTimeDelta(months = it.value)
-                    "week" -> DateTimeDelta(weeks = it.value)
-                    "day" -> DateTimeDelta(days = it.value)
-                    "hour" -> DateTimeDelta(hours = it.value)
-                    "minute" -> DateTimeDelta(minutes = it.value)
-                    "second" -> DateTimeDelta(seconds = it.value)
+                    "year" -> DateTimeDelta(years = longVal)
+                    "month" -> DateTimeDelta(months = longVal)
+                    "week" -> DateTimeDelta(weeks = longVal)
+                    "day" -> DateTimeDelta(days = longVal)
+                    "hour" -> DateTimeDelta(hours = longVal)
+                    "minute" -> DateTimeDelta(minutes = longVal)
+                    "second" -> DateTimeDelta(seconds = longVal)
                     else -> {
-                        val seconds = UnitConverter.toBase(BigDecimal.valueOf(it.value), unit, variables).toLong()
+                        val seconds = UnitConverter.toBase(it.value, unit, variables).toLong()
                         DateTimeDelta(seconds = seconds)
                     }
                 }
@@ -1264,11 +1270,11 @@ class Evaluator(
     private fun mapDateTimeResult(res: DateTimeResult): EvaluationResult {
         return when (res) {
             is DateTimeResult.DayCount -> {
-                EvaluationResult(value = BigDecimal.valueOf(res.days * 86400L), unit = "d", dateTimeResult = res)
+                EvaluationResult(value = res.days.multiply(BigDecimal("86400")), unit = "d", dateTimeResult = res)
             }
             is DateTimeResult.TimeCount -> {
                 val unit = UnitConverter.findUnit(res.unit) ?: throw EvalException("Unknown unit: ${res.unit}")
-                EvaluationResult(value = UnitConverter.toBase(BigDecimal.valueOf(res.value), unit, variables), unit = res.unit, dateTimeResult = res)
+                EvaluationResult(value = UnitConverter.toBase(res.value, unit, variables), unit = res.unit, dateTimeResult = res)
             }
             is DateTimeResult.Duration -> {
                 EvaluationResult(

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/Evaluator.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/Evaluator.kt
@@ -1019,24 +1019,30 @@ class Evaluator(
     private fun toDateDelta(result: EvaluationResult): DateTimeDelta {
         result.dateTimeResult?.let {
             if (it is DateTimeResult.Duration) return it.delta
-            if (it is DateTimeResult.DayCount) return DateTimeDelta(days = it.days.toLong())
+            if (it is DateTimeResult.DayCount) {
+                val isWhole = it.days.remainder(BigDecimal.ONE).compareTo(BigDecimal.ZERO) == 0
+                return if (isWhole) {
+                    DateTimeDelta(days = it.days.toLong())
+                } else {
+                    val seconds = (it.days * BigDecimal("86400")).toLong()
+                    DateTimeDelta(seconds = seconds)
+                }
+            }
             if (it is DateTimeResult.TimeCount) {
                 val unit = UnitConverter.findUnit(it.unit)!!
-                val longVal = it.value.toLong()
-                val delta = when (unit.name.lowercase()) {
-                    "year" -> DateTimeDelta(years = longVal)
-                    "month" -> DateTimeDelta(months = longVal)
-                    "week" -> DateTimeDelta(weeks = longVal)
-                    "day" -> DateTimeDelta(days = longVal)
-                    "hour" -> DateTimeDelta(hours = longVal)
-                    "minute" -> DateTimeDelta(minutes = longVal)
-                    "second" -> DateTimeDelta(seconds = longVal)
-                    else -> {
-                        val seconds = UnitConverter.toBase(it.value, unit, variables).toLong()
-                        DateTimeDelta(seconds = seconds)
+                val isWhole = it.value.remainder(BigDecimal.ONE).compareTo(BigDecimal.ZERO) == 0
+                val unitName = unit.name.lowercase()
+                if (isWhole && unitName in setOf("year", "month", "week", "day")) {
+                    val longVal = it.value.toLong()
+                    return when (unitName) {
+                        "year" -> DateTimeDelta(years = longVal)
+                        "month" -> DateTimeDelta(months = longVal)
+                        "week" -> DateTimeDelta(weeks = longVal)
+                        else -> DateTimeDelta(days = longVal)
                     }
                 }
-                return delta
+                val seconds = UnitConverter.toBase(it.value, unit, variables).toLong()
+                return DateTimeDelta(seconds = seconds)
             }
         }
 
@@ -1047,24 +1053,24 @@ class Evaluator(
         }
 
         val amount = (result.value ?: BigDecimal.ZERO).divide(unit.factor, mc)
-        val amountLong = amount.toLong()
-        return when (unit.name.lowercase()) {
-            "year" -> DateTimeDelta(years = amountLong)
-            "month" -> DateTimeDelta(months = amountLong)
-            "week" -> DateTimeDelta(weeks = amountLong)
-            "day" -> DateTimeDelta(days = amountLong)
-            "hour" -> DateTimeDelta(hours = amountLong)
-            "minute" -> DateTimeDelta(minutes = amountLong)
-            "second" -> DateTimeDelta(seconds = amountLong)
-            "lustrum" -> DateTimeDelta(years = amountLong * 5)
-            "decade" -> DateTimeDelta(years = amountLong * 10)
-            "century" -> DateTimeDelta(years = amountLong * 100)
-            "millennium" -> DateTimeDelta(years = amountLong * 1000)
-            else -> {
-                val seconds = UnitConverter.toBase(amount, unit, variables)
-                DateTimeDelta(seconds = seconds.toLong())
+        val isWhole = amount.remainder(BigDecimal.ONE).compareTo(BigDecimal.ZERO) == 0
+        val unitName = unit.name.lowercase()
+        if (isWhole) {
+            val amountLong = amount.toLong()
+            when (unitName) {
+                "year" -> return DateTimeDelta(years = amountLong)
+                "month" -> return DateTimeDelta(months = amountLong)
+                "week" -> return DateTimeDelta(weeks = amountLong)
+                "day" -> return DateTimeDelta(days = amountLong)
+                "lustrum" -> return DateTimeDelta(years = amountLong * 5)
+                "decade" -> return DateTimeDelta(years = amountLong * 10)
+                "century" -> return DateTimeDelta(years = amountLong * 100)
+                "millennium" -> return DateTimeDelta(years = amountLong * 1000)
             }
         }
+
+        val seconds = UnitConverter.toBase(amount, unit, variables).toLong()
+        return DateTimeDelta(seconds = seconds)
     }
 
     private fun applyOp(left: BigDecimal, op: TokenKind, right: BigDecimal): BigDecimal = when (op) {

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/Parser.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/Parser.kt
@@ -529,20 +529,20 @@ class Parser(private val tokens: List<Token>) {
                         numericValue *= multiplier
                     }
                 }
-
                 parseQuantityIfPossible(Expr.NumberLiteral(numericValue))
             }
-
 
             TokenKind.IDENTIFIER -> {
                 val nameToken = advance()
                 val name = nameToken.lexeme
-                if (name.equals("days", ignoreCase = true) && peekKind() == TokenKind.KW_BETWEEN) {
+                val timeUnit = UnitConverter.findUnit(name)
+                val isTimeUnit = timeUnit != null && timeUnit.category == UnitCategory.TIME
+                if (isTimeUnit && peekKind() == TokenKind.KW_BETWEEN) {
                     advance()
                     val start = parseExpression()
                     expect(TokenKind.KW_AND)
                     val end = parseAddSub(allowUnitConversion = false)
-                    var unit: String? = "days"
+                    var unit: String? = name
                     if (peekKind() == TokenKind.KW_IN && tokens.getOrNull(pos + 1)?.kind == TokenKind.IDENTIFIER) {
                         val nextLexeme = tokens[pos + 1].lexeme
                         if (UnitConverter.findUnit(nextLexeme)?.category == UnitCategory.TIME) {
@@ -552,13 +552,12 @@ class Parser(private val tokens: List<Token>) {
                         }
                     }
                     Expr.DateInterval(start, end, projectionUnit = unit, inclusive = false, absolute = true)
-                }
- else if (name.equals("days", ignoreCase = true) &&
+                } else if (isTimeUnit &&
                     (peekKind() == TokenKind.KW_SINCE || peekKind() == TokenKind.KW_TILL || peekKind() == TokenKind.KW_UNTIL)
                 ) {
                     val op = advance().kind
                     val base = parseAddSub(allowUnitConversion = false)
-                    var unit: String? = "days"
+                    var unit: String? = name
                     if (peekKind() == TokenKind.KW_IN && tokens.getOrNull(pos + 1)?.kind == TokenKind.IDENTIFIER) {
                         val nextLexeme = tokens[pos + 1].lexeme
                         if (UnitConverter.findUnit(nextLexeme)?.category == UnitCategory.TIME) {
@@ -567,12 +566,7 @@ class Parser(private val tokens: List<Token>) {
                             unit = nextLexeme
                         }
                     }
-                    if (unit != null && !unit.equals("days", ignoreCase = true)) {
-                        // Return as a TimeCount if a specific unit is requested
-                        Expr.DayCountQuery(op, base, projectionUnit = unit)
-                    } else {
-                        Expr.DayCountQuery(op, base)
-                    }
+                    Expr.DayCountQuery(op, base, projectionUnit = unit)
                 } else if (peekKind() == TokenKind.LPAREN) {
                     // e.g. sqrt(16), pow(2, 8)
                     advance() // skip past "("

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/Parser.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/Parser.kt
@@ -557,16 +557,17 @@ class Parser(private val tokens: List<Token>) {
                 ) {
                     val op = advance().kind
                     val base = parseAddSub(allowUnitConversion = false)
-                    var unit: String? = name
+                    val queryUnit: String = name
+                    var projUnit: String? = name
                     if (peekKind() == TokenKind.KW_IN && tokens.getOrNull(pos + 1)?.kind == TokenKind.IDENTIFIER) {
                         val nextLexeme = tokens[pos + 1].lexeme
                         if (UnitConverter.findUnit(nextLexeme)?.category == UnitCategory.TIME) {
                             advance() // consume "in"
                             advance() // consume unit
-                            unit = nextLexeme
+                            projUnit = nextLexeme
                         }
                     }
-                    Expr.DayCountQuery(op, base, projectionUnit = unit)
+                    Expr.DayCountQuery(op, base, unit = queryUnit, projectionUnit = projUnit)
                 } else if (peekKind() == TokenKind.LPAREN) {
                     // e.g. sqrt(16), pow(2, 8)
                     advance() // skip past "("

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorScreen.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/ui/calculator/CalculatorScreen.kt
@@ -2024,7 +2024,7 @@ private fun LineRow(
                 if (currentWord.isEmpty() || (currentWord.any { char -> char.isLetter() || char == '_' } &&
                     currentWord.all { char -> char.isLetterOrDigit() || char == '_' })) {
                     val prevToken = cleanTokens.getOrNull(cleanTokens.size - 2)
-                    val showUnits = prevToken?.kind == TokenKind.NUMBER
+                    val showUnits = prevToken?.kind == TokenKind.NUMBER || currentWord.isNotEmpty()
                     val unitsList = if (showUnits) {
                         UnitConverter.UNITS.flatMap { u -> u.symbols.map { Suggestion(it, SuggestionType.UNIT) } }
                     } else emptyList()

--- a/app/src/test/java/com/vishaltelangre/nerdcalci/core/DateTimeFeaturesTest.kt
+++ b/app/src/test/java/com/vishaltelangre/nerdcalci/core/DateTimeFeaturesTest.kt
@@ -677,7 +677,9 @@ class DateTimeFeaturesTest {
         "minutes between datetime(2024, 1, 1, 12, 0, 0) and datetime(2024, 1, 1, 12, 45, 0)",
         "date(2024, 1, 1) to date(2024, 5, 15)",
         "days between date(2024, 1, 1) and date(2024, 1, 2) in seconds",
-        "datetimeZ(2024, 1, 1, 0, 0, 0, \"UTC\") + (hours between dt1 and dt2)"
+        "datetimeZ(2024, 1, 1, 0, 0, 0, \"UTC\") + (hours between dt1 and dt2)",
+        "hours since date(2024, 1, 1)",
+        "hours until date(2030, 1, 1)"
     ) { results ->
         assertEquals("1.2708333333 d", results[2].result)
         assertEquals("30.5 h", results[3].result)
@@ -694,5 +696,7 @@ class DateTimeFeaturesTest {
         assertEquals("4 mo 14 d", results[14].result)
         assertEquals("86400 s", results[15].result)
         assertEquals("Jan 2, 2024, 6:30 AM UTC", results[16].result)
+        assertTrue(results[17].result.endsWith(" h"))
+        assertTrue(results[18].result.endsWith(" h"))
     }
 }

--- a/app/src/test/java/com/vishaltelangre/nerdcalci/core/DateTimeFeaturesTest.kt
+++ b/app/src/test/java/com/vishaltelangre/nerdcalci/core/DateTimeFeaturesTest.kt
@@ -658,4 +658,39 @@ class DateTimeFeaturesTest {
             assertEquals("May 7", results[2].result)
         }
     }
+
+    @Test
+    fun `precision date time queries and units`() = testCalculate(
+        "dt1 = datetimeZ(2024, 1, 1, 12, 0, 0, \"UTC\")",
+        "dt2 = datetimeZ(2024, 1, 2, 18, 30, 0, \"UTC\")",
+        "days between dt1 and dt2",
+        "hours between dt1 and dt2",
+        "minutes between dt1 and dt2",
+        "seconds between dt1 and dt2",
+        "hours since dt2",
+        "minutes since dt2",
+        "seconds since dt2",
+        "ceil(days between dt1 and dt2)",
+        "floor(days between dt1 and dt2)",
+        "days between date(2024, 1, 1) and date(2024, 1, 10)",
+        "hours between datetime(2024, 1, 1, 12, 0, 0) and datetime(2024, 1, 2, 18, 30, 0)",
+        "minutes between datetime(2024, 1, 1, 12, 0, 0) and datetime(2024, 1, 1, 12, 45, 0)",
+        "date(2024, 1, 1) to date(2024, 5, 15)",
+        "days between date(2024, 1, 1) and date(2024, 1, 2) in seconds"
+    ) { results ->
+        assertEquals("1.2708333333 d", results[2].result)
+        assertEquals("30.5 h", results[3].result)
+        assertEquals("1830 min", results[4].result)
+        assertEquals("109800 s", results[5].result)
+        assertTrue(results[6].result.endsWith(" h"))
+        assertTrue(results[7].result.endsWith(" min"))
+        assertTrue(results[8].result.endsWith(" s"))
+        assertEquals("2.0 d", results[9].result)
+        assertEquals("1.0 d", results[10].result)
+        assertEquals("9 d", results[11].result)
+        assertEquals("30.5 h", results[12].result)
+        assertEquals("45 min", results[13].result)
+        assertEquals("4 mo 14 d", results[14].result)
+        assertEquals("86400 s", results[15].result)
+    }
 }

--- a/app/src/test/java/com/vishaltelangre/nerdcalci/core/DateTimeFeaturesTest.kt
+++ b/app/src/test/java/com/vishaltelangre/nerdcalci/core/DateTimeFeaturesTest.kt
@@ -676,7 +676,8 @@ class DateTimeFeaturesTest {
         "hours between datetime(2024, 1, 1, 12, 0, 0) and datetime(2024, 1, 2, 18, 30, 0)",
         "minutes between datetime(2024, 1, 1, 12, 0, 0) and datetime(2024, 1, 1, 12, 45, 0)",
         "date(2024, 1, 1) to date(2024, 5, 15)",
-        "days between date(2024, 1, 1) and date(2024, 1, 2) in seconds"
+        "days between date(2024, 1, 1) and date(2024, 1, 2) in seconds",
+        "datetimeZ(2024, 1, 1, 0, 0, 0, \"UTC\") + (hours between dt1 and dt2)"
     ) { results ->
         assertEquals("1.2708333333 d", results[2].result)
         assertEquals("30.5 h", results[3].result)
@@ -692,5 +693,6 @@ class DateTimeFeaturesTest {
         assertEquals("45 min", results[13].result)
         assertEquals("4 mo 14 d", results[14].result)
         assertEquals("86400 s", results[15].result)
+        assertEquals("Jan 2, 2024, 6:30 AM UTC", results[16].result)
     }
 }

--- a/fastlane/metadata/android/en-US/changelogs/494.txt
+++ b/fastlane/metadata/android/en-US/changelogs/494.txt
@@ -1,0 +1,1 @@
+- Added support for sub-day time unit queries (`hours since`, `minutes since`, `seconds since`, etc.) and decimal precision for date/time queries (Issue: #218).


### PR DESCRIPTION
- Fixes https://github.com/vishaltelangre/NerdCalci/issues/218.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for sub-day time unit queries (hours/minutes/seconds) and higher decimal precision for date/time calculations.
  * Expanded interval query syntax (including unit projection via `in <unit>`) with improved rounding behaviors.
  * Improved time unit autocomplete for clearer suggestions.
* **Documentation**
  * Updated date/time interval query documentation with full syntax, examples, and an expanded reference table.
* **Bug Fixes**
  * Improved precision and output formatting for fractional day/time results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->