### PR TITLE
Exclude standalone aggregate results from total and grand_total calculations to prevent double-counting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.9.5] - 2026-07-27
+### Fixed
+- Fixed `grand_total` and other dynamic variables double-counting subtotals by automatically excluding standalone aggregate results (Issue: #221).
+
 ## [4.9.4] - 2026-07-23
 ### Added
 - Added support for sub-day time unit queries (`hours since`, `minutes since`, `seconds since`, etc.) and decimal precision for date/time queries (Issue: #218).

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -326,7 +326,7 @@ rent + utilities # Total housing cost
 
 ### Sum / Total
 
-Use `sum` or `total` to get the sum of all line results above, up to the nearest blank/comment/error line.
+Use `sum` or `total` to get the sum of all line results above, up to the nearest blank/comment/error line. Standalone aggregate line results (such as `total`, `avg`, etc.) within the block are automatically ignored to prevent double-counting.
 
 ```text
 groceries = 45.50
@@ -358,7 +358,7 @@ tax = sum * 0.10    # evaluates to 10
 
 ### Grand total
 
-Use `grand_total` or `grand_sum` to get the sum of **all** line results in the file above the current line, crossing blank/comment/error block boundaries.
+Use `grand_total` or `grand_sum` to get the sum of **all** line results in the file above the current line, crossing blank/comment/error block boundaries. Standalone aggregate line results (such as `total`, `avg`, `grand_total`, etc.) are automatically excluded from the calculation.
 
 ```text
 # Section A
@@ -371,7 +371,7 @@ rent = 1000
 utilities = 150
 total               # evaluates to 1150  (block sum)
 
-grand_total         # 2310, sum of all results above
+grand_total         # 1155, sum of all non-aggregate results above (3 + 2 + 1000 + 150)
 ```
 
 Unlike `sum`/`total`, blank and comment lines do **not** reset `grand_total` — it always accumulates everything above.
@@ -386,7 +386,7 @@ tax = grand_total * 0.10
 
 ### Average
 
-Use `avg` or `average` to get the mathematical average of all line results above, up to the nearest blank/comment/error line.
+Use `avg` or `average` to get the mathematical average of all line results above, up to the nearest blank/comment/error line. Standalone aggregate line results within the block are automatically ignored.
 
 ```text
 jan = 100
@@ -418,7 +418,7 @@ half_avg = avg / 2  # evaluates to 25
 
 ### Min / Max
 
-Use `min` (or `minimum`) and `max` (or `maximum`) to find the smallest or largest line result above, up to the nearest blank/comment/error line.
+Use `min` (or `minimum`) and `max` (or `maximum`) to find the smallest or largest line result above, up to the nearest blank/comment/error line. Standalone aggregate line results within the block are automatically ignored.
 
 ```text
 jan = 100

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
     defaultConfig {
         applicationId = "com.vishaltelangre.nerdcalci"
         minSdk = 23
-        versionCode = 494
-        versionName = "4.9.4"
+        versionCode = 495
+        versionName = "4.9.5"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/Evaluator.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/Evaluator.kt
@@ -17,7 +17,8 @@ data class EvaluationResult(
     val explicitRational: Boolean = false,
     val forceFloat: Boolean = false,
     val dateTimeResult: DateTimeResult? = null,
-    val stringResult: String? = null
+    val stringResult: String? = null,
+    val isDynamicAggregate: Boolean = false
 )
 
 /**

--- a/app/src/main/java/com/vishaltelangre/nerdcalci/core/MathEngine.kt
+++ b/app/src/main/java/com/vishaltelangre/nerdcalci/core/MathEngine.kt
@@ -86,6 +86,19 @@ object MathEngine {
         '\u2019'  // Right Single Quotation Mark (Grouping - e.g. Switzerland)
     )
 
+    /**
+     * Subset of dynamic variable keywords that represent aggregate computations.
+     * Standalone results from these keywords are excluded from other aggregates'
+     * input to prevent double-counting.
+     */
+    private val AGGREGATE_DYNAMIC_VARIABLES: Set<String> = setOf(
+        "sum", "total",
+        "grand_total", "grand_sum",
+        "avg", "average",
+        "min", "minimum",
+        "max", "maximum"
+    )
+
     private val RESERVED_DYNAMIC_VARIABLES: Set<String> = DYNAMIC_VARIABLES.keys + setOf(
         TokenKind.KW_TODAY, TokenKind.KW_YESTERDAY, TokenKind.KW_TOMORROW, TokenKind.KW_NOW,
         TokenKind.KW_BEFORE, TokenKind.KW_AFTER, TokenKind.KW_AGO, TokenKind.KW_FROM,
@@ -156,7 +169,12 @@ object MathEngine {
                 injectDynamicVariables(context)
                 val result = evaluateLine(line.expression, context, loader, loadingStack)
                 val hasResult = result.value != null || result.dateTimeResult != null || result.stringResult != null
-                context.lineResults.add(if (hasResult) result else null)
+                val taggedResult = if (hasResult) {
+                    if (isStandaloneDynamicAggregate(line.expression, context.userAssignedDynamicVariables))
+                        result.copy(isDynamicAggregate = true)
+                    else result
+                } else null
+                context.lineResults.add(taggedResult)
                 trackDynamicVariableAssignment(line.expression, context.userAssignedDynamicVariables)
             } catch (e: Exception) {
                 if (e is CircularReferenceException && loadingStack.isNotEmpty()) throw e
@@ -251,7 +269,12 @@ object MathEngine {
                     return@map line.copy(result = "")
                 }
 
-                lineResults.add(result)
+                // Tag standalone aggregate lines so other aggregates can exclude them
+                lineResults.add(
+                    if (isStandaloneDynamicAggregate(line.expression, userAssignedDynamicVariables))
+                        result.copy(isDynamicAggregate = true)
+                    else result
+                )
 
                 // Track if user explicitly assigned a dynamic variable name
                 trackDynamicVariableAssignment(line.expression, userAssignedDynamicVariables)
@@ -335,6 +358,21 @@ object MathEngine {
     }
 
     /**
+     * Returns `true` if [expression] is a standalone reference to an aggregate
+     * dynamic variable (e.g. bare "total", "avg").  Lines like "total * 2" or
+     * "tax = total * 0.10" return `false` because they use the variable inside
+     * a larger expression.
+     */
+    private fun isStandaloneDynamicAggregate(
+        expression: String,
+        userAssigned: Set<String>
+    ): Boolean {
+        val hashIdx = expression.indexOf('#')
+        val stripped = (if (hashIdx >= 0) expression.substring(0, hashIdx) else expression).trim()
+        return stripped in AGGREGATE_DYNAMIC_VARIABLES && stripped !in userAssigned
+    }
+
+    /**
      * Inject each registered dynamic variable into [variables] by calling its computation
      * function against the current [lineResults].  Skips any name the user has
      * explicitly assigned.
@@ -357,7 +395,9 @@ object MathEngine {
         val blockResults = mutableListOf<EvaluationResult>()
         for (i in lineResults.indices.reversed()) {
             val result = lineResults[i] ?: break
-            blockResults.add(0, result)
+            if (!result.isDynamicAggregate) {
+                blockResults.add(0, result)
+            }
         }
         return blockResults
     }
@@ -464,7 +504,7 @@ object MathEngine {
      * physical unit.
      */
     private fun computeGrandTotal(lineResults: List<EvaluationResult?>): EvaluationResult {
-        val allResults = lineResults.filterNotNull()
+        val allResults = lineResults.filter { it != null && !it.isDynamicAggregate }.filterNotNull()
         if (allResults.isEmpty()) return EvaluationResult(BigDecimal.ZERO)
 
         val targetUnitSymbol = validateUnitsAndGetTarget(allResults, "Summation")

--- a/app/src/test/java/com/vishaltelangre/nerdcalci/core/MathEngineTest.kt
+++ b/app/src/test/java/com/vishaltelangre/nerdcalci/core/MathEngineTest.kt
@@ -1791,8 +1791,8 @@ class MathEngineTest {
                 assertEquals("", result[3].result)
                 assertEquals("5.0", result[4].result)
                 assertEquals("5.0", result[5].result) // only c = 5 in this block
-                // grand_total sees: 10, 20, 30, 5, 5 -> 70
-                assertEquals("70.0", result[6].result)
+                // grand_total sees: 10, 20, 5 -> 35 (excludes standalone aggregate results)
+                assertEquals("35.0", result[6].result)
             }
 
     @Test
@@ -1926,6 +1926,156 @@ class MathEngineTest {
         val result = MathEngine.calculateFrom(lines, changedIndex = 3)
         assertEquals(1, result.size)
         assertEquals("60.0", result[0].result)
+    }
+
+    @Test
+    fun `total excludes standalone total in same block`() =
+        testCalculate("10", "20", "total", "5", "total") { result ->
+            assertEquals("30.0", result[2].result)  // first total: 10 + 20
+            assertEquals("5.0", result[3].result)
+            // second total: 10 + 20 + 5 = 35 (excludes the first total's result)
+            assertEquals("35.0", result[4].result)
+        }
+
+    @Test
+    fun `total excludes standalone avg in same block`() =
+        testCalculate("10", "30", "avg", "total") { result ->
+            assertEquals("20.0", result[2].result)  // avg(10, 30) = 20
+            // total: 10 + 30 = 40 (excludes standalone avg)
+            assertEquals("40.0", result[3].result)
+        }
+
+    @Test
+    fun `avg excludes standalone total in same block`() =
+        testCalculate("10", "20", "total", "avg") { result ->
+            assertEquals("30.0", result[2].result)  // total: 10 + 20
+            // avg: avg(10, 20) = 15 (excludes standalone total)
+            assertEquals("15.0", result[3].result)
+        }
+
+    @Test
+    fun `min excludes standalone aggregates in same block`() =
+        testCalculate("10", "20", "total", "min") { result ->
+            assertEquals("30.0", result[2].result)  // total: 10 + 20
+            // min: min(10, 20) = 10 (excludes standalone total)
+            assertEquals("10.0", result[3].result)
+        }
+
+    @Test
+    fun `max excludes standalone aggregates in same block`() =
+        testCalculate("10", "20", "total", "max") { result ->
+            assertEquals("30.0", result[2].result)  // total: 10 + 20
+            // max: max(10, 20) = 20 (excludes standalone total)
+            assertEquals("20.0", result[3].result)
+        }
+
+    @Test
+    fun `standalone aggregate does not break block boundary`() =
+        testCalculate("10", "total", "20", "total") { result ->
+            assertEquals("10.0", result[1].result)  // first total: just 10
+            assertEquals("20.0", result[2].result)
+            // second total: 10 + 20 = 30 (skips first total but doesn't break scan)
+            assertEquals("30.0", result[3].result)
+        }
+
+    // --- Grand-total level ---
+
+    @Test
+    fun `grand_total excludes standalone total lines`() =
+        testCalculate("10", "20", "total", "", "5", "grand_total") { result ->
+            assertEquals("30.0", result[2].result)
+            // grand_total: 10 + 20 + 5 = 35 (excludes standalone total)
+            assertEquals("35.0", result[5].result)
+        }
+
+    @Test
+    fun `grand_total excludes standalone avg lines`() =
+        testCalculate("10", "30", "avg", "", "5", "grand_total") { result ->
+            assertEquals("20.0", result[2].result)
+            // grand_total: 10 + 30 + 5 = 45 (excludes standalone avg)
+            assertEquals("45.0", result[5].result)
+        }
+
+    @Test
+    fun `grand_total excludes standalone min and max lines`() =
+        testCalculate("10", "20", "min", "", "30", "max", "", "grand_total") { result ->
+            assertEquals("10.0", result[2].result)  // min
+            assertEquals("30.0", result[5].result)  // max
+            // grand_total: 10 + 20 + 30 = 60 (excludes standalone min and max)
+            assertEquals("60.0", result[7].result)
+        }
+
+    @Test
+    fun `grand_total excludes other standalone grand_totals`() =
+        testCalculate("10", "", "20", "grand_total", "", "5", "grand_total") { result ->
+            // first grand_total: 10 + 20 = 30
+            assertEquals("30.0", result[3].result)
+            // second grand_total: 10 + 20 + 5 = 35 (excludes first grand_total)
+            assertEquals("35.0", result[6].result)
+        }
+
+    // --- Expressions that USE aggregates (not standalone) ---
+
+    @Test
+    fun `total includes result of expression using total`() =
+        testCalculate("10", "20", "total * 2", "total") { result ->
+            assertEquals("60.0", result[2].result)  // total*2 = 30*2 = 60
+            // "total * 2" is not standalone, so it's included
+            // total: 10 + 20 + 60 = 90
+            assertEquals("90.0", result[3].result)
+        }
+
+    @Test
+    fun `grand_total includes result of expression using total`() =
+        testCalculate("10", "20", "total * 2", "", "5", "grand_total") { result ->
+            assertEquals("60.0", result[2].result)
+            // grand_total: 10 + 20 + 60 + 5 = 95 (includes total*2 because it's not standalone)
+            assertEquals("95.0", result[5].result)
+        }
+
+    @Test
+    fun `grand_total includes last and prev results`() =
+        testCalculate("10", "last", "", "20", "grand_total") { result ->
+            assertEquals("10.0", result[1].result)  // last = 10
+            // grand_total: 10 + 10 + 20 = 40 (includes "last" — it's not an aggregate)
+            assertEquals("40.0", result[4].result)
+        }
+
+    @Test
+    fun `standalone aggregate with comment suffix is still excluded`() =
+        testCalculate("10", "20", "total # subtotal", "", "5", "grand_total") { result ->
+            assertEquals("30.0", result[2].result)
+            // grand_total: 10 + 20 + 5 = 35
+            assertEquals("35.0", result[5].result)
+        }
+
+    @Test
+    fun `calculateFrom correctly handles grand_total excluding aggregates`() = runBlocking {
+        val lines = listOf(
+            createLine("10", sortOrder = 0),
+            createLine("20", sortOrder = 1),
+            createLine("total", sortOrder = 2),
+            createLine("", sortOrder = 3),
+            createLine("5", sortOrder = 4),
+            createLine("grand_total", sortOrder = 5)
+        )
+        val result = MathEngine.calculateFrom(lines, changedIndex = 5)
+        assertEquals(1, result.size)
+        assertEquals("35.0", result[0].result) // 10 + 20 + 5, not 65
+    }
+
+    @Test
+    fun `calculateFrom correctly handles block total excluding aggregates`() = runBlocking {
+        val lines = listOf(
+            createLine("10", sortOrder = 0),
+            createLine("total", sortOrder = 1),
+            createLine("20", sortOrder = 2),
+            createLine("total", sortOrder = 3)
+        )
+        val result = MathEngine.calculateFrom(lines, changedIndex = 3)
+        assertEquals(1, result.size)
+        // total: 10 + 20 = 30 (skips standalone total)
+        assertEquals("30.0", result[0].result)
     }
 
     @Test

--- a/fastlane/metadata/android/en-US/changelogs/495.txt
+++ b/fastlane/metadata/android/en-US/changelogs/495.txt
@@ -1,0 +1,1 @@
+- Fixed `grand_total` and other dynamic variables double-counting subtotals by automatically excluding standalone aggregate results (Issue: #221).


### PR DESCRIPTION
- Fixes https://github.com/vishaltelangre/NerdCalci/issues/221.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `grand_total` and other aggregate calculations that could double-count standalone subtotals.
  * Standalone aggregate results are now automatically excluded from subsequent block and cross-block calculations.
  * Aggregates used within expressions continue to be included correctly.

* **Documentation**
  * Clarified aggregate behavior and updated examples.

* **Chores**
  * Updated the app version to 4.9.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->