### PR TITLE
Upgrade to Android API 36

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.9.6] - 2026-07-28
+### Changed
+- Target Android 16 (API level 36).
+
 ## [4.9.5] - 2026-07-27
 ### Fixed
 - Fixed `grand_total` and other dynamic variables double-counting subtotals by automatically excluding standalone aggregate results (Issue: #221).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,13 +6,14 @@ plugins {
 
 android {
     namespace = "com.vishaltelangre.nerdcalci"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "com.vishaltelangre.nerdcalci"
         minSdk = 23
-        versionCode = 495
-        versionName = "4.9.5"
+        targetSdk = 36
+        versionCode = 496
+        versionName = "4.9.6"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/fastlane/metadata/android/en-US/changelogs/496.txt
+++ b/fastlane/metadata/android/en-US/changelogs/496.txt
@@ -1,0 +1,1 @@
+- Target Android 16 (API level 36).

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,14 +1,14 @@
 [versions]
-agp = "9.0.0"
+agp = "9.0.1"
 coreKtx = "1.10.1"
 junit = "4.13.2"
 junitVersion = "1.1.5"
 espressoCore = "3.5.1"
 lifecycleRuntimeKtx = "2.6.1"
 activityCompose = "1.8.0"
-kotlin = "2.0.21"
+kotlin = "2.2.10"
 composeBom = "2024.09.00"
-ksp = "2.0.21-1.0.26"
+ksp = "2.3.2"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }


### PR DESCRIPTION
### Why

<img alt="2026-07-28_12-11" src="https://github.com/user-attachments/assets/05f628c4-595f-493f-8764-a4751e251cdb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Updated the Android app to target Android 16 (API level 36).
  * Released version 4.9.6 with updated version metadata.
  * Updated the Android release changelog to reflect the new target platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->